### PR TITLE
[Chore] New Notes notation

### DIFF
--- a/docs/documentation/maya/1.0.0/ribbon.md
+++ b/docs/documentation/maya/1.0.0/ribbon.md
@@ -9,8 +9,8 @@ The Ribbon Muscle deformer requires the following inputs to be provided:
 - <b class="mesh_color"> Attachments </b> to which the simulated muscle will be attached to. Any tranform node can be used (e.g. bones, locators, meshes, etc). This input is optional and unlimited.
 - <b class="mesh_color"> Muscle Geometry </b> that the ribbon muscle deformer will be applied onto.
 
-!!! Notes
-    - It is not mandatory to select the attachments on creation of the ribbon muscle deformer. We can add and remove attachments after creating the deformer, check this [advanced section](#how-to-add-and-remove-attachments) for further details.
+> [!NOTE]
+> - It is not mandatory to select the attachments on creation of the ribbon muscle deformer. We can add and remove attachments after creating the deformer, check this [advanced section](#how-to-add-and-remove-attachments) for further details.
 
 ## Create Ribbon Muscle
 


### PR DESCRIPTION
@carlosmonteagudoinbibo this is our proposal for the new Notes/Warnings notation system

the main issue with the previous one (!!! Notes) is that its four spaces indentation is parsed by Markdown as a code block, so we lose its inner formatting

we can use this one 

```
> [!NOTE]
> - It is not mandatory to select the attachments on creation of the ribbon muscle deformer. We can add and remove attachments after creating the deformer, check this [advanced section](#how-to-add-and-remove-attachments) for further details.
```

that leads to a result of this kind:

> [!NOTE]
> - It is not mandatory to select the attachments on creation of the ribbon muscle deformer. We can add and remove attachments after creating the deformer, check this [advanced section](#how-to-add-and-remove-attachments) for further details.

what do you think?