### PR TITLE
[Fix] Footnote

### DIFF
--- a/docs/documentation/maya/1.0.0/simshape.md
+++ b/docs/documentation/maya/1.0.0/simshape.md
@@ -39,8 +39,7 @@ In order to add or remove any of those optional meshes, a set of menu items are 
 
 # Attributes
 
-[^1]:
-  Soft range: higher values can be used.
+[^1]: Soft range: higher values can be used.
 
 <style>
 table th:first-of-type {


### PR DESCRIPTION
@carlosmonteagudoinbibo this carriage return after the footnote notation is not a valid markdown sytax, it leads to a footnote without text, removing it will render it correctly