### PR TITLE
[Fix] missing line before heading

### DIFF
--- a/docs/documentation/maya/1.0.0/simshape.md
+++ b/docs/documentation/maya/1.0.0/simshape.md
@@ -18,6 +18,7 @@ The Simshape deformer requires the following inputs to be provided:
     - If <b class="mesh_color">R</b> is not provided, the system will use the initial state of <b class="mesh_color">S</b> as the rest mesh.
     - If <b class="mesh_color">D</b> is not provided, the simulation will not produce activations.
     - If <b class="mesh_color">A</b> is not provided, the system will use the input mesh to the deformer (<b class="mesh_color">S</b>) as animated mesh.
+
 ## Create Simshape
 
   1. Select the meshes in the following order:


### PR DESCRIPTION
@carlosmonteagudoinbibo here we have a missing line before an heading, this prevents the markdown engine to parse it as an `<h2>` element