### PR TITLE
fix typo in pagename

### DIFF
--- a/docs/maya/index.md
+++ b/docs/maya/index.md
@@ -8,6 +8,6 @@
 - [AdnMuscle](muscle)
 - [AdnRibbonMuscle](ribbon)
 - [AdnSimshape](simshape)
-- [AdnSkinMerge](skin_erge)
+- [AdnSkinMerge](skin_merge)
 - [AdnEdgeEvaluator](edge_evaluator)
 - [Tools](tools)


### PR DESCRIPTION
@carlosmonteagudoinbibo i fixed `skin_erge` → `skin_merge` to avoid a 404 error on the documentation site

note: don't know why github is highlighting row 13 as changed as well, I think it is just a whitespace or something similar