### PR TITLE
fix relative paths

### DIFF
--- a/docs/maya/muscle.md
+++ b/docs/maya/muscle.md
@@ -205,7 +205,7 @@ Once the AdnMuscle deformer is created, it is possible to add and remove new tar
     3. Press the ![Remove Targets button](images/adn_remove_target.png){style="width:4%"} button in the AdonisFX shelf or press *Remove Targets* in the AdonisFX menu from the Edit Muscle submenu. 
     4. Alternatively, if only the mesh with the AdnMuscle deformer is selected, when pressing the ![Remove Targets button](images/adn_remove_target.png){style="width:4%"} button, all targets will be removed (transform and mesh targets).
 
-Targets can be any transformation nodes or meshes. On one hand, transformation nodes such as joints or locators are used to create attachments to their world transformation matrices. On the other hand, meshes are used to create attachments to geometry and slide on geometry constraints. Check [A Simple Setup](maya/simple_setup#AdnMuscle) for more information on how to paint the influence maps for the mentioned constraints.
+Targets can be any transformation nodes or meshes. On one hand, transformation nodes such as joints or locators are used to create attachments to their world transformation matrices. On the other hand, meshes are used to create attachments to geometry and slide on geometry constraints. Check [A Simple Setup](simple_setup#AdnMuscle) for more information on how to paint the influence maps for the mentioned constraints.
 
 > [!NOTE]
 > - Attachments to geometry and slide on geometry constraints are meant to simulate interaction muscle to bones. The use of simulated muscles as geometry targets for other muscles is not supported.


### PR DESCRIPTION
@carlosmonteagudoinbibo I found some issues like this one (was alarmed by the number of documentation 404 pages that were triggered after the v1.1.0 update)

basically, all links in documentation are relative to the current page, so instead of 

```
[A Simple Setup](maya/simple_setup#AdnMuscle)
```

this is the correct way to address that page from `/maya/muscle.md`

```
[A Simple Setup](simple_setup#AdnMuscle)
```

otherwise the resulting link will be `https://inbibo.co.uk/docs/adonisfx/v1.1.0/maya/maya/simple_setup#AdnMuscle`

I fond other example of this (in maya/ribbon.md for example), but I only searched  the `maya/simple_setup` string, maybe a double check on all file may be required in order to avoid path errors

let me know if you need further info from me or if I can help you someway
