### PR TITLE
#89 Slide Collision Projection Patch Documentation

### DIFF
--- a/docs/maya/simshape.md
+++ b/docs/maya/simshape.md
@@ -120,6 +120,9 @@ To remove any of these meshes from AdnSimshape follow this procedure:
 | **Keep Orientation**     | Boolean | True | ✓ | Flag to preserve the initial orientation of the vertices relative to the collider when handling collisions. If disabled, the mesh will suffer no changes if the orientation of the collider varies. |
 | **Max Sliding Distance** | Float   | 0.0  | ✗ | Maximum distance (in world units) the simulated vertex is allowed to slide relative to the collider. If the value provided is considered too high for a given collider mesh, a warning will be displayed to the user. Has a range of \[0.0, 10.0\]. Upper limit is soft, higher values can be used. |
 
+> [!NOTE]
+> - v1.1.2 introduced changes to the projection of the Slide Collision Constraint which might alter the final look of the collisions in previous scenes whenever there are intersections during simulation of the simulated mesh with the collider.
+
 #### Attraction Settings
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |

--- a/docs/maya/simshape.md
+++ b/docs/maya/simshape.md
@@ -120,9 +120,6 @@ To remove any of these meshes from AdnSimshape follow this procedure:
 | **Keep Orientation**     | Boolean | True | ✓ | Flag to preserve the initial orientation of the vertices relative to the collider when handling collisions. If disabled, the mesh will suffer no changes if the orientation of the collider varies. |
 | **Max Sliding Distance** | Float   | 0.0  | ✗ | Maximum distance (in world units) the simulated vertex is allowed to slide relative to the collider. If the value provided is considered too high for a given collider mesh, a warning will be displayed to the user. Has a range of \[0.0, 10.0\]. Upper limit is soft, higher values can be used. |
 
-> [!NOTE]
-> - v1.1.2 introduced changes to the projection of the Slide Collision Constraint which might alter the final look of the collisions in previous scenes whenever there are intersections during simulation of the simulated mesh with the collider.
-
 #### Attraction Settings
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,11 +4,11 @@
 
 ### Bug Fixes
 
-- Fixed a bug in the projection of the Slide Collision Constraints that, when having Compute Collisions ON and Keep Orientation ON, was overcorrecting the constraints past the collision threshold when the simulated mesh intersected the collider a considerable amount. This resulted in flickering and artifacts that were more noticeable when gravity was applied to the system. *AdonisFX-1258*
+- Fixed a bug in the projection of the Slide Collision Constraints that when having Compute Collisions ON and Keep Orientation ON was applying an incorrect amount of correction past the collision threshold when the simulated mesh intersected the collider more than the collision threshold distance. *AdonisFX-1258*
 
 ### Considerations
 
-- Due to the fix introduced in this version the results are mathematically more correct. However, given that the bugfix was introduced in the core of the Slide Collision Constraints full backwards compatibility can't be ensured.
+- Due to the fix introduced in this version the results are more mathematically correct. However, given that the bugfix was introduced in the core logic of the Slide Collision Constraints full backwards compatibility can't be ensured.
 
 ## Version 1.1.1
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,11 +4,7 @@
 
 ### Bug Fixes
 
-- Fixed a bug in the projection of the Slide Collision Constraints that when having Compute Collisions ON and Keep Orientation ON was applying an incorrect amount of correction past the collision threshold when the simulated mesh intersected the collider more than the collision threshold distance. *AdonisFX-1258*
-
-### Considerations
-
-- Due to the fix introduced in this version the results are more mathematically correct. However, given that the bugfix was introduced in the core logic of the Slide Collision Constraints full backwards compatibility can't be ensured.
+- Fixed a bug in the Slide Collision Constraints that was overcorrecting in case of intersection with the collider with a magnitude greater than the collision threshold. *AdonisFX-1258*
 
 ## Version 1.1.1
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Version 1.1.2
+
+### Bug Fixes
+
+- Fixed a bug in the projection of the Slide Collision Constraints that, when having Compute Collisions ON and Keep Orientation ON, was overcorrecting the constraints past the collision threshold when the simulated mesh intersected the collider a considerable amount. This resulted in flickering and artifacts that were more noticeable when gravity was applied to the system. *AdonisFX-1258*
+
+### Considerations
+
+- Due to the fix introduced in this version the results are mathematically more correct. However, given that the bugfix was introduced in the core of the Slide Collision Constraints full backwards compatibility can't be ensured.
+
 ## Version 1.1.1
 
 ### Bug Fixes


### PR DESCRIPTION
# Description
This PR is intended to document the changes added for v1.1.2 patch about the slide collision constraint projection. It addresses:

- Release notes changes and clarifications on the Slide Collision Constraint projection

# Changes (Preview tool was not refreshing)
![image](https://github.com/user-attachments/assets/81c59527-53e6-462d-9299-e9fa8d2ac557)

PR for issue: #89 