### PR TITLE
#209 Removed exporter and importer limitations and AdnGlue paint workaround

### DIFF
--- a/docs/maya/nodes/glue.md
+++ b/docs/maya/nodes/glue.md
@@ -117,6 +117,9 @@ In order to provide more artistic control, some key parameters of the AdnGlue so
   <figcaption><b>Figure 2</b>: Example of painted weights on the glue layer, labeled as: <b>a)</b> Glue Resistance, <b>b)</b> Max Glue Distance Multiplier and <b>c)</b> Shape Preservation (Optional painting). </figcaption>
 </figure>
 
+> [!NOTE]
+> In case you are experiencing issues trying to paint weights on the AdnGlue output geometry, find in this [Simple Setup Section for AdnGlue](/maya/simple_setup#workaround_for_painting_adnglue_weights) a proposed workaround.
+
 ## Debugger
 
 In order to better visualize node constraints and attributes in the Maya viewport there is the option to enable the debugger, found in the dropdown menu labeled *Debug* in the Attribute Editor.

--- a/docs/maya/nodes/glue.md
+++ b/docs/maya/nodes/glue.md
@@ -118,7 +118,7 @@ In order to provide more artistic control, some key parameters of the AdnGlue so
 </figure>
 
 > [!NOTE]
-> In case you are experiencing issues trying to paint weights on the AdnGlue output geometry, find in this [Simple Setup Section for AdnGlue](/maya/simple_setup#adnglue) a proposed workaround.
+> In case you are experiencing issues trying to paint weights on the AdnGlue output geometry, find in this [simple setup section for AdnGlue](../simple_setup#AdnGlue) a proposed workaround.
 
 ## Debugger
 

--- a/docs/maya/nodes/glue.md
+++ b/docs/maya/nodes/glue.md
@@ -118,7 +118,7 @@ In order to provide more artistic control, some key parameters of the AdnGlue so
 </figure>
 
 > [!NOTE]
-> In case you are experiencing issues trying to paint weights on the AdnGlue output geometry, find in this [Simple Setup Section for AdnGlue](/maya/simple_setup#workaround_for_painting_adnglue_weights) a proposed workaround.
+> In case you are experiencing issues trying to paint weights on the AdnGlue output geometry, find in this [Simple Setup Section for AdnGlue](/maya/simple_setup#adnglue) a proposed workaround.
 
 ## Debugger
 

--- a/docs/maya/nodes/glue.md
+++ b/docs/maya/nodes/glue.md
@@ -118,7 +118,7 @@ In order to provide more artistic control, some key parameters of the AdnGlue so
 </figure>
 
 > [!NOTE]
-> In case you are experiencing issues trying to paint weights on the AdnGlue output geometry, find in this [simple setup section for AdnGlue](../simple_setup#AdnGlue) a proposed workaround.
+> In case you are experiencing issues trying to paint weights on the AdnGlue output geometry, find in the [limitations section](glue#limitations) a proposed workaround.
 
 ## Debugger
 
@@ -154,3 +154,12 @@ Once the AdnGlue node is created, it is possible to add new inputs and remove cu
 > [!NOTE]
 > Adding and removing inputs will automatically update the painted maps.
 > Undoing the removal of inputs does not restore the previously painted values for the restored inputs. The painted values are set to the default value.
+
+## Limitations
+After creating the AdnGlue node, it may be possible to smoothen out the resulting geometry (generally called *AdnGlue1_GEO*). This can be done using an AdnRelax node or any other deformer to reduce artifacts (like deltaMush).
+In such cases, painting the AdnGlue weights on the output geometry using Maya's paint tool may not be possible.
+Here is a workaround to enable painting AdnGlue weights again:
+1. Create a cube from the Poly Modelling shelf (remove the *polyCube* node and keep only *pCubeShape1*).
+2. Using a script or the node editor, connect *AdnGlue1.outputMesh* to *pCubeShape1.inMesh*
+3. Using a script or the node editor, connect *pCubeShape1.outMesh* to *AdnGlue1_GEOShapeOrig.inMesh* (the original mesh created by Maya after applying AdnRelax, for example).
+4. To paint AdnGlue weights, select the *pCube* and follow the standard Maya procedure for painting weights. To paint AdnRelax weights, select the *AdnGlue1_GEO* and follow the same procedure.

--- a/docs/maya/scripts.md
+++ b/docs/maya/scripts.md
@@ -11,8 +11,6 @@ Currently, the script allows to mirror:
 - The three types of **AdonisFX sensors** (i.e. AdnSensorPosition, AdnSensorDistance, and AdnSensorRotation).
 - **AdnActivation nodes**, including their input and output connections.
 
-Please, check this [section](#limitations) to know more about the current limitations.
-
 ### Requirements
 
 In order to use the mirroring script, the rig must meet the following requirements to ensure a successful transfer of the muscle setup:

--- a/docs/maya/scripts.md
+++ b/docs/maya/scripts.md
@@ -11,6 +11,8 @@ Currently, the script allows to mirror:
 - The three types of **AdonisFX sensors** (i.e. AdnSensorPosition, AdnSensorDistance, and AdnSensorRotation).
 - **AdnActivation nodes**, including their input and output connections.
 
+Please, check this [section](#limitations) to know more about the current limitations.
+
 ### Requirements
 
 In order to use the mirroring script, the rig must meet the following requirements to ensure a successful transfer of the muscle setup:

--- a/docs/maya/simple_setup.md
+++ b/docs/maya/simple_setup.md
@@ -257,7 +257,7 @@ The *Glue Resistance* map modulates the strength of the glue constraint. To redu
 Finally, shape preservation constraints help to maintain the original shape of the muscles. These constraints are useful if the gluing produces undesired shape on the output mesh. If that is not the case, then this map can stay unmodified (0.0) which will make the solver run faster. If shape preservation is required, then increase the values on those areas where the shape has been altered during the simulation.
 
 > [!NOTE]
-> In case you are experiencing issues trying to paint weights on the AdnGlue output geometry, find in the [limitations section](nodes/glue#limitations) a proposed workaround.
+> In case you are experiencing issues trying to paint weights on the AdnGlue output geometry, find in the [limitations section of AdnGlue](nodes/glue#limitations) a proposed workaround.
 
 ## AdnFat
 

--- a/docs/maya/simple_setup.md
+++ b/docs/maya/simple_setup.md
@@ -256,14 +256,8 @@ The *Glue Resistance* map modulates the strength of the glue constraint. To redu
 
 Finally, shape preservation constraints help to maintain the original shape of the muscles. These constraints are useful if the gluing produces undesired shape on the output mesh. If that is not the case, then this map can stay unmodified (0.0) which will make the solver run faster. If shape preservation is required, then increase the values on those areas where the shape has been altered during the simulation.
 
-### Workaround for Painting AdnGlue Weights
-After creating the AdnGlue node, it may be possible to smoothen out the resulting geometry (generally called *AdnGlue1_GEO*). This can be done using an AdnRelax node or any other deformer to reduce artifacts (like deltaMush).
-In such cases, painting the AdnGlue weights on the output geometry using Maya's paint tool may not be possible.
-Here is a workaround to enable painting AdnGlue weights again:
-1. Create a cube from the Poly Modelling shelf (remove the *polyCube* node and keep only *pCubeShape1*).
-2. Using a script or the node editor, connect *AdnGlue1.outputMesh* to *pCubeShape1.inMesh*
-3. Using a script or the node editor, connect *pCubeShape1.outMesh* to *AdnGlue1_GEOShapeOrig.inMesh* (the original mesh created by Maya after applying AdnRelax, for example).
-4. To paint AdnGlue weights, select the *pCube* and follow the standard Maya procedure for painting weights. To paint AdnRelax weights, select the *AdnGlue1_GEO* and follow the same procedure.
+> [!NOTE]
+> In case you are experiencing issues trying to paint weights on the AdnGlue output geometry, find in the [limitations section](nodes/glue#limitations) a proposed workaround.
 
 ## AdnFat
 

--- a/docs/maya/simple_setup.md
+++ b/docs/maya/simple_setup.md
@@ -256,6 +256,15 @@ The *Glue Resistance* map modulates the strength of the glue constraint. To redu
 
 Finally, shape preservation constraints help to maintain the original shape of the muscles. These constraints are useful if the gluing produces undesired shape on the output mesh. If that is not the case, then this map can stay unmodified (0.0) which will make the solver run faster. If shape preservation is required, then increase the values on those areas where the shape has been altered during the simulation.
 
+### Workaround for Painting AdnGlue Weights
+After creating the AdnGlue node, it may be possible to smoothen out the resulting geometry (generally called *AdnGlue1_GEO*). This can be done using an AdnRelax node or any other deformer to reduce artifacts (like deltaMush).
+In such cases, painting the AdnGlue weights on the output geometry using Maya's paint tool may not be possible.
+Here is a workaround to enable painting AdnGlue weights again:
+1. Create a cube from the Poly Modelling shelf (remove the *polyCube* node and keep only *pCubeShape1*).
+2. Using a script or the node editor, connect *AdnGlue1.outputMesh* to *pCubeShape1.inMesh*
+3. Using a script or the node editor, connect *pCubeShape1.outMesh* to *AdnGlue1_GEOShapeOrig.inMesh* (the original mesh created by Maya after applying AdnRelax, for example).
+4. To paint AdnGlue weights, select the *pCube* and follow the standard Maya procedure for painting weights. To paint AdnRelax weights, select the *AdnGlue1_GEO* and follow the same procedure.
+
 ## AdnFat
 
 To create a basic scenario using the AdnFat deformer, start with a scene with the following elements:

--- a/docs/maya/tools/exporter.md
+++ b/docs/maya/tools/exporter.md
@@ -58,4 +58,6 @@ Depending on the complexity of the rig, the export process might take a few seco
 
 > [!NOTE]
 > The Export Tool is labeled as *Beta* since it relies on the experimental [API](../api).
+
+> [!NOTE]
 > Exporting data is required to be executed on rest frame.

--- a/docs/maya/tools/exporter.md
+++ b/docs/maya/tools/exporter.md
@@ -57,7 +57,5 @@ Depending on the complexity of the rig, the export process might take a few seco
 </figure>
 
 > [!NOTE]
-> The Export Tool is labeled as *Beta* since it relies on the experimental [API](../api).
-
-> [!NOTE]
-> Exporting data is required to be executed on rest frame.
+> - The Export Tool is labeled as *Beta* since it relies on the experimental [API](../api).
+> - Exporting data is required to be executed on rest frame.

--- a/docs/maya/tools/exporter.md
+++ b/docs/maya/tools/exporter.md
@@ -58,7 +58,3 @@ Depending on the complexity of the rig, the export process might take a few seco
 
 > [!NOTE]
 > The Export Tool is labeled as *Beta* since it relies on the experimental [API](../api).
-
-## Limitations
-
-- If Maya nodes are applied to the simulated geometries (e.g. Delta Mush applied to the simulated skin), it is not guaranteed that the node order in the Maya node graph will be preserved after importing.

--- a/docs/maya/tools/exporter.md
+++ b/docs/maya/tools/exporter.md
@@ -58,3 +58,4 @@ Depending on the complexity of the rig, the export process might take a few seco
 
 > [!NOTE]
 > The Export Tool is labeled as *Beta* since it relies on the experimental [API](../api).
+> Exporting data is required to be executed on rest frame.

--- a/docs/maya/tools/importer.md
+++ b/docs/maya/tools/importer.md
@@ -77,7 +77,3 @@ The previous steps corresponds to importing a rig that was exported from the sam
 
 > [!NOTE]
 > The Import Tool is labeled as *Beta* since it relies on the experimental [API](../api).
-
-## Limitations
-
-- If Maya nodes are applied to the simulated geometries (e.g. Delta Mush applied to the simulated skin), it is not guaranteed that the node order in the Maya node graph will be preserved after importing.

--- a/docs/maya/tools/importer.md
+++ b/docs/maya/tools/importer.md
@@ -76,7 +76,5 @@ The previous steps corresponds to importing a rig that was exported from the sam
 <!-- To complete if we are finally allowed to expose Kobun asset) -->
 
 > [!NOTE]
-> The Import Tool is labeled as *Beta* since it relies on the experimental [API](../api).
-
-> [!NOTE]
-> Importing data is required to be executed on rest frame.
+> - The Import Tool is labeled as *Beta* since it relies on the experimental [API](../api).
+> - Importing data is required to be executed on rest frame.

--- a/docs/maya/tools/importer.md
+++ b/docs/maya/tools/importer.md
@@ -77,3 +77,4 @@ The previous steps corresponds to importing a rig that was exported from the sam
 
 > [!NOTE]
 > The Import Tool is labeled as *Beta* since it relies on the experimental [API](../api).
+> Importing data is required to be executed on rest frame.

--- a/docs/maya/tools/importer.md
+++ b/docs/maya/tools/importer.md
@@ -77,4 +77,6 @@ The previous steps corresponds to importing a rig that was exported from the sam
 
 > [!NOTE]
 > The Import Tool is labeled as *Beta* since it relies on the experimental [API](../api).
+
+> [!NOTE]
 > Importing data is required to be executed on rest frame.


### PR DESCRIPTION
# Description
This pull request includes documentation updates to improve the clarity and usability of the Maya tools, scripts, and nodes. The most important changes include the addition of a workaround for painting AdnGlue weights, removal of limitations sections, and added notes for better user guidance.

Documentation improvements:

* [`docs/maya/nodes/glue.md`](diffhunk://#diff-8219fd613679b75b50805c9c8eb78f793466b76a33d9f0cde2e98039ce4eb9c7R120-R122): Added a note with a link to a workaround for painting weights on the AdnGlue output geometry.
* [`docs/maya/simple_setup.md`](diffhunk://#diff-ec00520d417d312fc1b0acf98d7e759829dca4b678b132ef51d245bac3aa0a04R259-R267): Added a detailed workaround section for painting AdnGlue weights when using deformers like AdnRelax.

Removal of limitations sections:

* [`docs/maya/scripts.md`](diffhunk://#diff-b8a43cfe3c274f8a10d76d79a178b7494d857a9b33e40a9f46e23eac32584c50L14-L15): Removed the limitations section to streamline the document.
* [`docs/maya/tools/exporter.md`](diffhunk://#diff-7805c68d8e212447efdea8c81ee4cc690c19f3af1ad74c12e52a1c4ab11fc474L61-L64): Removed the limitations section regarding node order preservation after importing.
* [`docs/maya/tools/importer.md`](diffhunk://#diff-c0d705f7a14c9637d1a4e68dca3021f3752d1282e69b8ade36c53d80d20321c9L80-L83): Removed the limitations section regarding node order preservation after importing.

# [Preview](https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2F8d6120fce0483df6249b3d1b4fe2d0a4315868be%2Fdocs%2Fmaya%2Fnodes%2Fglue.md%23limitations)