### PR TITLE
#223 Fix adonis support email address to use adonis.support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Welcome to the technical documentation of AdonisFX where we provide you with all the information you need to use the software in your digital characters. If you need more information or help, please do not hesitate to send an email to **adnsupport@inbibo.co.uk** with your consultation.
+Welcome to the technical documentation of AdonisFX where we provide you with all the information you need to use the software in your digital characters. If you need more information or help, please do not hesitate to send an email to **adonis.support@inbibo.co.uk** with your consultation.
 
 ## Key Values
 

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -98,7 +98,7 @@ To activate AdonisFX in Offline Node-Locked Interactive Trial mode:
 
   1. Go to `AdonisFX/bin` in the AdonisFX installation folder.
   2. Run `TrialOfflineRequest` with admin privileges. An XML file `TrialOfflineRequest.xml` will be generated in the same folder.
-  4. Send the request file to **adnsupport@inbibo.co.uk** providing enough information to backtrack the source of the activation request.
+  4. Send the request file to **adonis.support@inbibo.co.uk** providing enough information to backtrack the source of the activation request.
   5. In a maximum of 24h a `TrialOfflineResponse.xml` will be returned to the source e-mail address.
   6. Download and save the response in the same folder `AdonisFX/bin`.
   7. Execute `TrialOfflineResponse` (also in `AdonisFX/bin`) with admin privileges.

--- a/docs/maya/api.md
+++ b/docs/maya/api.md
@@ -6,6 +6,6 @@
 > - This API is experimental, and will be subject to changes in following versions of AdonisFX.
 > - The use of this API in production applications is not supported.
 
-A Python API has been developed to allow Technical Directors implementing custom Python scripts to export and rebuild AdonisFX rigs from script. It allows users to extract the setup from a rig in Maya and rebuild it in another Maya scene. As this API is experimental, please do not hesitate to send an email to **adnsupport@inbibo.co.uk** to provide any feedback and/or requests. The support and development teams will work together to incorporate users' feedback and refine the implementation.
+A Python API has been developed to allow Technical Directors implementing custom Python scripts to export and rebuild AdonisFX rigs from script. It allows users to extract the setup from a rig in Maya and rebuild it in another Maya scene. As this API is experimental, please do not hesitate to send an email to **adonis.support@inbibo.co.uk** to provide any feedback and/or requests. The support and development teams will work together to incorporate users' feedback and refine the implementation.
 
 The API can be found in `AdonisFX/python/adn/api/adnx.py` and the definitions can be imported with the Python command `from adn.api.adnx import *`.


### PR DESCRIPTION
This pull request updates the support email address across the documentation for consistency and accuracy. The changes ensure that users are directed to the correct email address for support and feedback.

### Documentation updates:

* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L3-R3): Updated the support email address from **adnsupport@inbibo.co.uk** to **adonis.support@inbibo.co.uk** in the introduction section.
* [`docs/licensing.md`](diffhunk://#diff-0786e270da5bcdbd8e63ec86259eba865dbaf82fc1a34e4e8bf6be27cdb44a5bL101-R101): Changed the email address in the instructions for offline trial activation to **adonis.support@inbibo.co.uk**.
* [`docs/maya/api.md`](diffhunk://#diff-5456bc64a23647615abc92bb923e469a047de811558ade95d7bd0a054596cf39L9-R9): Replaced the support email address with **adonis.support@inbibo.co.uk** in the description of the experimental Python API.


## Tests

[Docs preview](https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2F3813b23fe5770aac5944d52d18464ffcd7f76599%2Fdocs%2Findex.md)