### PR TITLE
#226 Release Notes for 1.7.0

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,39 @@
 # Release Notes
 
+## Version 1.7.0
+2025-05-22
+
+### Core
+- Added a layered activation system in AdnMuscle and AdnRibbonMuscle solvers.
+- Added activation-driven volume gain to AdnMuscle solver.
+- Improved AdnGlue solver to support two simulation modes: static and dynamic.
+- Added substeps to the AdnGlue solver.
+- Added Self-Collisions to the AdnGlue solver.
+- Added volume preservation to the AdnGlue solver.
+
+### Maya
+- Added an AdnTurbo script to build the whole AdonisFX rig from Python.
+- Implemented a UI to execute AdnTurbo.
+- Added dynamic attributes to the AdnGlue node (e.g. substeps, gravity, soft constraints, attenuation, damping).
+- Added volume preservation attribute to the AdnGlue node.
+- Added AdnRemap node to remove dependency with the Maya remapValue nodes.
+- Added a new array attribute to the AdnMuscle and AdnRibbonMuscle to support activation layers.
+- Added a read-only attribute to expose the muscle activation result of the activation layers in AdnMuscle and AdnRibbonMuscle nodes.
+- Extended Experimental API to support AdnRibbonMuscle, AdnSimshape, AdnEdgeEvaluator and AdnRemap nodes.
+- Extended mirror script and tool to support AdnRemap node.
+- Extended mirror script and tool to support activation layers.
+
+### Improvements
+- Place steps attribute above iterations attribute in the Attribute Editor Template of AdnSkin and AdnFat deformers.
+- Updated support email address in the EULA.
+- Improved AdnActivation node support in the Experimental API to support value plugs without connections.
+
+### Bug Fixes
+- Fixed a bug that was preventing skipping the computation of the slide collision constraints when the Compute Collisions checkbox was disabled in AdnSimshape. *AdonisFX-2043*
+
+### Deprecated
+- Removed Python code (UI, tools and utils) that was supporting the outdated Import and Export tools deprecated in 1.5.0.
+
 ## Version 1.6.2
 2025-04-25
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -16,7 +16,7 @@
 - Implemented a UI to execute AdnTurbo.
 - Added dynamic attributes to the AdnGlue node (e.g. substeps, gravity, soft constraints, attenuation, damping).
 - Added volume preservation attribute to the AdnGlue node.
-- Added AdnRemap node to remove dependency with the Maya remapValue nodes.
+- Added AdnRemap node to remove dependency on the Maya remapValue nodes.
 - Added a new array attribute to the AdnMuscle and AdnRibbonMuscle to support activation layers.
 - Added a read-only attribute to expose the muscle activation result of the activation layers in AdnMuscle and AdnRibbonMuscle nodes.
 - Extended Experimental API to support AdnRibbonMuscle, AdnSimshape, AdnEdgeEvaluator and AdnRemap nodes.


### PR DESCRIPTION
### Preview

[GO](https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2F05fd3099514d8d91a0a2c6af4fcf3657e58ed194%2Fdocs%2Frelease_notes.md)

### Summary

This pull request updates the release notes to include the changes introduced in version 1.7.0. The changes span multiple areas, including core functionality, Maya integration, general improvements, bug fixes, and deprecations.

### Core Enhancements:
* Introduced a layered activation system and activation-driven volume gain in the `AdnMuscle` and `AdnRibbonMuscle` solvers.
* Enhanced the `AdnGlue` solver with support for static and dynamic simulation modes, substeps, self-collisions, and volume preservation.

### Maya Integration:
* Added the `AdnTurbo` script and UI for building the AdonisFX rig from Python.
* Introduced dynamic and volume preservation attributes to the `AdnGlue` node, and a new array attribute for activation layers in `AdnMuscle` and `AdnRibbonMuscle`.
* Added the `AdnRemap` node to eliminate dependency on Maya's `remapValue` nodes, and extended the Experimental API and mirror tools to support new nodes and features.

### Improvements:
* Reorganized attributes in the Attribute Editor Template for better usability and updated the support email address in the EULA.