### PR TITLE
#251 Release notes for v1.6.4

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Version 1.6.4
+2025-06-09
+
+### Improvements
+- Improved floating licenses to drop the lease instantly when the plugin is unloaded or the Maya process ends.
+- Improved material switch in the Paint Tool to support multiple materials on the same paintable geometry.
+
+### Bug Fixes
+- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *AdonisFX-2111*
+
 ## Version 1.6.3
 2025-06-06
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,7 @@
 2025-06-09
 
 ### Improvements
-- Improved floating licenses to drop the lease instantly when the plugin is unloaded or the Maya process ends.
+- Improved floating licensing system to drop the lease instantly on Maya exit.
 - Improved material switch in the Paint Tool to support multiple materials on the same paintable geometry.
 
 ### Bug Fixes


### PR DESCRIPTION
Updated release notes to document v1.6.4 changes

### Improvements
- Improved floating licenses to drop the lease instantly when the plugin is unloaded or the Maya process ends.
- Improved material switch in the Paint Tool to support multiple materials on the same paintable geometry.

### Bug Fixes
- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *AdonisFX-2111*

### Preview

[go](https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2F1b737127d3d780edd76e15b24720f47dff799821%2Fdocs%2Frelease_notes.md)

![image](https://github.com/user-attachments/assets/6e578bdf-0e04-41f8-b907-dc5d51b13287)
