### PR TITLE
Add v1.6.3 and v1.6.4 to the release notes

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -34,6 +34,22 @@
 ### Deprecated
 - Removed Python code (UI, tools and utils) that was supporting the outdated Import and Export tools deprecated in 1.5.0.
 
+## Version 1.6.4
+2025-06-09
+
+### Improvements
+- Improved floating licensing system to drop the lease instantly on Maya exit.
+- Improved material switch in the Paint Tool to support multiple materials on the same paintable geometry.
+
+### Bug Fixes
+- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *AdonisFX-2111*
+
+## Version 1.6.3
+2025-06-06
+
+### Improvements
+- Improved logger to display more information in batch mode. *AdonisFX-2100*
+
 ## Version 1.6.2
 2025-04-25
 


### PR DESCRIPTION
This is a hotfix to make sure that the listed versions from the main docs (currently pointing to v1.7.0) is consistent with the versions listed in previous/older versions