### PR TITLE
#255 Release notes for v1.7.2

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Version 1.7.2
+2025-06-13
+
+### Improvements
+- Improved floating licensing system to drop the lease instantly on Maya exit.
+- Improved material switch in the Paint Tool to support multiple materials on the same paintable geometry.
+
+### Bug Fixes
+- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *AdonisFX-2111*
+
 ## Version 1.7.1
 2025-06-09
 


### PR DESCRIPTION
This pull request updates the release notes for version 1.7.2, documenting improvements and a bug fix.

### Updates to release notes:

* **Improvements**:
  - Enhanced the floating licensing system to immediately release the lease upon Maya exit.
  - Updated the Paint Tool to allow switching materials on paintable geometry with multiple materials.

* **Bug Fixes**:
  - Resolved an issue where the muscle solver failed to initialize if the input geometry contained disconnected primitives. (*AdonisFX-2111*)
  
  ### Preview
  
  [GO](https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2F74b6060d85de2fefb1b28841833ed065e8d8e6e4%2Fdocs%2Frelease_notes.md)
  
  
![image](https://github.com/user-attachments/assets/21f99b63-ecdf-4163-aa3c-1ad96f8e5c7e)
