### PR TITLE
#258 docs release notes for1.7.3

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,7 @@
 2025-10-22
 
 ### Bug Fixes
-- Fixed an error that was making the custom paint context fail in Maya 2026. *AdonisFX-2419*
+- Resolved an issue that caused the custom paint context to fail in Maya 2026. *AdonisFX-2419*
 
 ## Version 1.7.2
 2025-06-12


### PR DESCRIPTION
This pull request adds release notes for version 1.7.3, documenting a bug fix related to the custom paint context in Maya 2026.

Release notes update:

* Added a new section for version 1.7.3 in `docs/release_notes.md`, noting the resolution of an issue with the custom paint context in Maya 2026.

<img width="1406" height="479" alt="image" src="https://github.com/user-attachments/assets/0fd2f524-4802-4b4c-8367-987a9b32fac1" />
