### PR TITLE
Release v1.7.3 for Maya

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Version 1.7.3
+2025-10-22
+
+### Bug Fixes
+- Resolved an issue that caused the custom paint context to fail in Maya 2026. *AdonisFX-2419*
+
 ## Version 1.7.2
 2025-06-12
 


### PR DESCRIPTION
This pull request adds release notes for version 1.7.3, documenting a bug fix for a custom paint context issue in Maya 2026.

Release notes update:

* Added a new section for version 1.7.3 in `docs/release_notes.md`, describing the resolution of a bug that caused the custom paint context to fail in Maya 2026.