### PR TITLE
#266 Document SaveServer program

### DIFF
--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -219,7 +219,7 @@ When launching AdonisFX in the target DCC, if the connection to the active licen
 
 ### Save Server Tool (Optional)
 
-The first time that the client attempts to load AdonisFX with a floating license, the IP address and the port specified in the environment variables are saved in the machine. Optionally, you can execute the **SaveServer** utility to save the server information before launching the Maya or Houdini process that will attempt to load AdonisFX. In some specific environments where the client machines do not have permission to store this information, using this tool with admin privileges would become a requirement.
+The first time that the client attempts to load AdonisFX with a floating license, the IP address and the port specified in the environment variables are saved in the machine. Optionally, you can execute the **SaveServer** utility to save the server information before launching the DCC process that will attempt to load AdonisFX. In some specific environments where the client machines do not have permission to store this information, using this tool with admin privileges would become a requirement.
 
 This utility works in **Windows** and **Linux** and can be used to save the server information of Interactive licenses or Batch licenses. It can be executed by providing the settings either via prompts in the terminal or via command-line arguments. Internally, the program does the following:
 
@@ -234,12 +234,11 @@ This utility works in **Windows** and **Linux** and can be used to save the serv
 
 | Argument | Required | Description |
 |---------|---------|-------------|
-| `<server_address>`        | yes | License server hostname or IP address. |
-| `<server_port>`           | yes | License server port (1–65535). |
-| `-b`, `--batch`           | no  | Use **batch** license (default). |
-| `-i`, `--interactive`     | no  | Use **interactive** license. |
-| `-d <base_dir>`           | no  | Base directory of the AdonisFX package containing the `AdonisFX` subfolder. |
-| `--directory=<base_dir>`  | no  | Same as above, using `=` syntax. |
+| `<server_address>`    | yes | License server hostname or IP address. |
+| `<server_port>`       | yes | License server port (1–65535). |
+| `-b`, `--batch`       | no  | Use **batch** license (default). |
+| `-i`, `--interactive` | no  | Use **interactive** license. |
+| `-d`, `--directory`   | no  | Base directory of the AdonisFX package containing the `AdonisFX` subfolder. |
 
 #### Input validation
 


### PR DESCRIPTION
## Description

This pull request adds comprehensive documentation for the new optional Save Server Tool utility for AdonisFX floating license configuration. The documentation explains what the tool does, how to use it, its arguments and input validation, example usage scenarios, and troubleshooting common errors.

**Save Server Tool documentation:**

* Added a new section describing the SaveServer utility, which allows users to pre-save floating license server information before launching AdonisFX, especially useful in restricted environments.
* Detailed the command-line arguments, input validation rules, and step-by-step usage instructions for both Windows and Linux platforms.
* Provided example commands for different scenarios, including batch and interactive licenses, and custom base directory usage.
* Included sample interactive session output and a troubleshooting section for common errors related to license file location and server configuration.

## Docs Preview

Try yourself: [GO](https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2Fb115acf05305fe08f6d80b4c10602f483557c33d%2Fdocs%2Flicensing.md)

### Screenshots

<img width="1707" height="1628" alt="Image" src="https://github.com/user-attachments/assets/1042d6a8-174f-45e8-90a3-752ca13f5c1d" />

<img width="1745" height="1810" alt="Image" src="https://github.com/user-attachments/assets/b1bb6b79-3c07-4a20-9d85-762a3126e216" />

<img width="1792" height="895" alt="Image" src="https://github.com/user-attachments/assets/fc156739-f16f-46bf-b463-9efd9965eef7" />