### PR TITLE
#356 Added important FAQ questions for Houdini

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -117,6 +117,29 @@ The second approach is to use nCloth to apply a pressured simulation. This solut
 
 As a final step for both approaches, you may want to smooth the resulting fascia geometry with sculpting tools to polish the final result.
 
+## Cross-DCC Support
+
+### In which scale do I have to work when transferring a rig from Maya to Houdini?
+Internally, our solvers always operate in centimeters (cm) across all supported DCCs. Since Maya uses centimeters by default, while Houdini typically uses meters (1 unit = 1 meter), rigs imported into Houdini usually need to be scaled up by a factor of 100 to match Maya's simulation scale.
+In some cases (for example, Houdini's Alembic SOP), this conversion may be applied automatically.
+A good way to verify the correct scale in Houdini is to check the point coordinates in the *Geometry Spreadsheet*. The values should be consistent with centimeter units.
+
+### Are there guidelines for building rigs in Houdini?
+Yes. Each deformer chain affecting a single geometry must be enclosed in a deformable region.
+A deformable region is defined using two SOP Null nodes with a specific naming convention:
+- Start node: `ADN_IN_<geo_name>`.
+- End node: `ADN_OUT_<geo_name>`.
+All AdonisFX deformers affecting `geo_name` should be placed between these nodes.
+This structure allows components such as the API to correctly identify which SOP nodes affect which geometries, ensuring smooth transfer to other DCCs.
+
+### Do geometries need preprocessing in Houdini?
+Yes. Before using AdonisFX:
+- Geometry must be unpacked.
+- PolySoup primitives are not supported and should be avoided.
+
+### Does AdonisFX in Houdini support transforms?
+No. AdonisFX operates purely in geometry (SOP) space. Any transforms applied at the object level (world transform matrices) are not supported. Make sure to apply transforms directly to point positions before processing geometry with AdonisFX.
+
 ## Debugging
 
 ### How can I change the logger level?


### PR DESCRIPTION
# Description
This pull request adds a new "Cross-DCC Support" section to the `docs/faq.md` documentation, providing detailed guidance for users transferring rigs and working with AdonisFX between Maya and Houdini. The section covers scale conversion, rigging guidelines, geometry preprocessing, and transform support.

Documentation updates for cross-DCC workflows:

* Added explanation of internal unit scale (centimeters) and instructions for scaling rigs when transferring from Maya (cm) to Houdini (m), including verification tips.
* Provided guidelines for building rigs in Houdini, introducing the requirement for deformable regions defined by specifically named SOP Null nodes to ensure compatibility and smooth transfer.
* Clarified preprocessing requirements for geometry in Houdini, such as unpacking geometry and avoiding PolySoup primitives.
* Specified that AdonisFX in Houdini does not support object-level transforms and that transforms must be applied directly to point positions.

### [Preview](https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2F531e83c81acf45f89cfee58029889ccc7e5d06b5%2Fdocs%2Ffaq.md)