### PR TITLE
Fixing docs before release of 2.0

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -72,10 +72,14 @@ AdnSimshape allows to add muscle activation alternatively without the need for t
 
 ### For what units is AdonisFX designed?
 
-The AdonisFX simulation engine works in centimeters. Maya units also work internally in centimeters, disregarding any preferences set for the viewport. AdonisFX then works in centimeters in conjunction with Maya, disregarding any working units set in the Maya preferences.
+The AdonisFX simulation engine works in centimeters. 
 
-It is typical in Maya to model creatures 10 times smaller in order to avoid precision issues. Imagine the example of a creature that is supposed to be 1.7 meters tall (170 Maya units). Then in Maya to avoid precision issues, this creature may be modeled to be 17 centimeters tall (17 Maya units).
-In this case you can adjust the simulation for this scaling factor by applying the AdonisFX Space Scale attribute to 10. This will ensure that AdonisFX will scale everything internally so that the simulation of the 17 units creature will look like if it was actually 170 units tall.
+For example for Maya, the unit system also work internally in centimeters, disregarding any preferences set for the viewport. AdonisFX then works in centimeters in conjunction with Maya, disregarding any working units set in the Maya preferences.
+
+For Houdini, the scene units are generally presented in meters. Given that AdonisFX works in centimeters internally, in some cases, the mesh has to be scaled accordingly to represent the right scaling. This may be one of the contributing factors to incorrect looking simulations when comparing to Maya.
+
+For example in Maya, is typical to model creatures 10 times smaller in order to avoid precision issues. Imagine the example of a creature that is supposed to be 1.7 meters tall (170 Maya units). Then in Maya to avoid precision issues, this creature may be modeled to be 17 centimeters tall (17 Maya units).
+In this case you can adjust the simulation for this scaling factor by applying the AdonisFX Space Scale attribute to 10. This will ensure that AdonisFX will scale everything internally so that the simulation of the 17 units creature will look like if it was actually 170 units tall. Similar criteria can be applied to Houdini, however, it is still advisable to check the scaling of the characters when transferring between DCCs.
 
 ### How can I transfer the results of skin simulation to the final mesh?
 Make use of the **AdnSkinMerge** deformer to blend animated and simulated meshes into a single final mesh. Create and configure the node providing the final mesh and add the simulation and animation meshes. Then you only need to paint the blend weight to define the influence of the simulated mesh targets over the animated ones. You can find more information in the **AdnSkinMerge** page.

--- a/docs/houdini/deformers/push.md
+++ b/docs/houdini/deformers/push.md
@@ -1,6 +1,6 @@
 # AdnPush
 
-AdnPush is a Houdini SOP designed to push a surface along the direction of its normals. This deformation can be applied outwards (i.e., the surface bulges and gains volume) or inwards (i.e., the surface shrinks and loses volume). This deformer is useful for refining meshes by increasing or decreasing their volume, as well as for modeling purposes. For example, a common use case is generating internal fascia geometry from skin geometry. Check [this section](../simple_setup#AdnPush) to see a simple setup of this.
+AdnPush is a Houdini SOP designed to push a surface along the direction of its normals. This deformation can be applied outwards (i.e., the surface bulges and gains volume) or inwards (i.e., the surface shrinks and loses volume). This deformer is useful for refining meshes by increasing or decreasing their volume, as well as for modeling purposes. For example, a common use case is generating internal fascia geometry from skin geometry. Check [this section](../simple_setup#adnpush) to see a simple setup of this.
 
 ## How to use
 
@@ -70,3 +70,9 @@ To provide more control, the AdnPush SOP includes two paintable attributes.
 
 > [!NOTE]
 > To tweak the point attributes of an AdnPush SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnPush SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnPush node.
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/deformers/relax.md
+++ b/docs/houdini/deformers/relax.md
@@ -83,3 +83,9 @@ To provide more control, some key parameters of the AdnRelax SOP are exposed as 
 
 > [!NOTE]
 > To tweak the point attributes of an AdnRelax SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnRelax SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnRelax node.
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/deformers/skin_merge.md
+++ b/docs/houdini/deformers/skin_merge.md
@@ -111,3 +111,9 @@ Once the AdnSkinMerge SOP is created, the input meshes (animation mesh list, sim
 
 > [!NOTE]
 > To tweak the point attributes of an AdnSkinMerge SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSkinMerge SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSkinMerge node.
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/index.md
+++ b/docs/houdini/index.md
@@ -20,7 +20,6 @@
     - [AdnRemap](utils/remap)
     - [AdnEdgeEvaluator](utils/edge_evaluator)
     - [AdnFiberGroom](utils/fiber_groom)
-    - [AdnLearnMusclePatches](utils/learn_muscle_patches)
 - Tools
     - [Turbo](tools/turbo_tool)
     - [Export](tools/exporter)

--- a/docs/houdini/scripts/io.md
+++ b/docs/houdini/scripts/io.md
@@ -74,7 +74,7 @@ The first argument `file_path` is required and it is the full path to the JSON f
 > [!NOTE]
 > The rig will be imported into the first found geometry node with the visibility flag on. For that reason it is advisable to have one single geometry node in the */obj* context or at least only one active.
 
-Find more information about the use of the import feature in the [Import](tools/importer) page.
+Find more information about the use of the import feature in the [Import](../tools/importer) page.
 
 ## Export
 
@@ -90,7 +90,7 @@ The first argument `file_path` is required and it is the full path to the JSON f
 > [!NOTE]
 > The rig will be exported from the first found geometry node with the visibility flag on. For that reason it is advisable to have one single geometry node in the */obj* context or at least only one active.
 
-Find more information about the use of the export feature in the [Export](tools/exporter) page.
+Find more information about the use of the export feature in the [Export](../tools/exporter) page.
 
 ## Limitations
 

--- a/docs/houdini/simple_setup.md
+++ b/docs/houdini/simple_setup.md
@@ -117,14 +117,13 @@ Once the sensor and locator are created, go to the *Input* tab of both nodes and
 Now that the locator is created it has to be connected to the deformer. In order to make this connection, use a detail or channel expression. This will allow for the AdnMuscle SOP to pick up the activation attribute from the locator:
 
   - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)`
-  - Channel expression: `ch("../L_adnLocatorRotation_armFlexionShape/adnActivationRotation")`
 
 <figure style="width:75%" markdown>
   ![Locator connected via detail expression](images/simple_setup_muscle_10.png)
   <figcaption><b>Figure 13</b>: Locator connected via detail expression.</figcaption>
 </figure>
 
-When the elbow is flexed (and therefore the angle from the locator gets smaller) the muscle activation will get higher, simulating a much more realistic scenario.
+When the elbow is flexed (and therefore the angle from the locator gets smaller) the muscle activation increases, simulating a much more realistic scenario.
 
 To tweak additional parameters of the AdnMuscle deformer, check this [page](solvers/muscle).
 

--- a/docs/houdini/solvers/fat.md
+++ b/docs/houdini/solvers/fat.md
@@ -206,3 +206,10 @@ To enable the debugger the *Debug* checkbox must be marked. To select the specif
 > [!NOTE]
 > - The width of the debug lines can be modified from the global viewport settings in Houdini.
 > - For better contrast while debugging, enable the *Dark* background option in the viewport settings.
+
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/solvers/glue.md
+++ b/docs/houdini/solvers/glue.md
@@ -18,6 +18,7 @@ To create an AdnGlue node within a Houdini scene, the following inputs must be p
 > [!NOTE]
 > - In the context of an AdonisFX rig, the merged geometries would generally be the output of the individually simulated muscles (via AdnMuscle or AdnRibbonMuscle SOPs). It is important to maintaining the piece attribute intact after merging them together to distinguish each separate muscle entity.
 > - The order in which the geometries are merged can affect the output of the simulation result.
+> - Depending on the ordering of the point id's in the input (non-consecutive) the point id ordering on the output may not match.
 
 
 The process to create an AdnGlue node is:
@@ -262,3 +263,9 @@ Once the AdnGlue SOP is created, it is possible to add new inputs and remove cur
 
 > [!NOTE]
 > Adding and removing inputs requires to revisit and update the paintable maps to ensure that the painted values are correct for the new list of geometries.
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/solvers/muscle.md
+++ b/docs/houdini/solvers/muscle.md
@@ -337,7 +337,7 @@ Once the AdnMuscle SOP is created, it is possible to add and remove attachments 
     3. Alternatively, to remove all attachments, click the **Clear** button of the *Attachments To Transform* multiparm.
     4. Make sure to recook the AdnMuscle at preroll start time for this change to take effect.
 
-Transformation nodes such as joints or locators are used to create attachments to their world transformation matrices. Meshes, on the other hand, are used to create attachment-to-geometry and slide-on-geometry constraints. Refer to [A Simple Setup](../simple_setup#AdnMuscle) for more information on painting influence maps for these constraints.
+Transformation nodes such as joints or locators are used to create attachments to their world transformation matrices. Meshes, on the other hand, are used to create attachment-to-geometry and slide-on-geometry constraints. Refer to [A Simple Setup](../simple_setup#adnmuscle) for more information on painting influence maps for these constraints.
 
 > [!NOTE]
 > - Attachment-to-geometry and slide-on-geometry constraints are intended to simulate muscle-to-bone and muscle-to-muscle interactions.
@@ -391,7 +391,7 @@ Not painting the fibers multiplier map will cause the muscle to contract uniform
 
 ### Activation Layers
 
-The activation layers allow to drive the muscle activation by multiple sensors combined together without the need of using an [AdnActivation](../utils#activation) node. In practice, having an AdnActivation node with multiple input sensors connected to the **activation** attribute of an AdnMuscle is equivalent to connecting those sensors directly to the activation list of that muscle.
+The activation layers allow to drive the muscle activation by multiple sensors combined together without the need of using an [AdnActivation](../utils/activation#adnactivation) node. In practice, having an AdnActivation node with multiple input sensors connected to the **activation** attribute of an AdnMuscle is equivalent to connecting those sensors directly to the activation list of that muscle.
 
 The activation layers contribute to the final activation of the muscle solver, where the first layer will always be the **activation** scalar attribute. Then, every value in the **activation list** array plug is applied on top taking into consideration the operator and the bypass flag. The resulting value is the global activation that the solver will use for the simulation, and it is written onto the read-only **output solver activation** attribute.
 
@@ -406,3 +406,10 @@ The operators available are:
 > [!NOTE]
 > - All operators will be evaluated from top to bottom (starting from the lowest index and ending on the last index used).
 > - The final value will be clamped in the range 0 to 1 to ensure that the solver activation is always normalized.
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
+

--- a/docs/houdini/solvers/ribbon.md
+++ b/docs/houdini/solvers/ribbon.md
@@ -330,7 +330,7 @@ Once the AdnRibbonMuscle SOP is created, it is possible to add and remove attach
     3. Alternatively, to remove all attachments, click the **Clear** button of the *Attachments To Transform* multiparm.
     4. Make sure to recook the AdnRibbonMuscle at preroll start time for this change to take effect.
 
-Transformation nodes such as joints or locators are used to create attachments to their world transformation matrices. Meshes, on the other hand, are used to create attachment-to-geometry and slide-on-geometry constraints. Refer to [A Simple Setup](../simple_setup#AdnRibbonMuscle) for more information on painting influence maps for these constraints.
+Transformation nodes such as joints or locators are used to create attachments to their world transformation matrices. Meshes, on the other hand, are used to create attachment-to-geometry and slide-on-geometry constraints. Refer to [A Simple Setup](../simple_setup#adnribbonmuscle) for more information on painting influence maps for these constraints.
 
 > [!NOTE]
 > - Attachment-to-geometry and slide-on-geometry constraints are intended to simulate muscle-to-bone and muscle-to-muscle interactions.
@@ -379,7 +379,7 @@ Not painting the fibers multiplier map will cause the muscle to contract uniform
 
 ### Activation Layers
 
-The activation layers allow to drive the muscle activation by multiple sensors combined together without the need of using an [AdnActivation](../utils#activation) node. In practice, having an AdnActivation node with multiple input sensors connected to the **activation** attribute of an AdnRibbonMuscle is equivalent to connecting those sensors directly to the activation list of that muscle.
+The activation layers allow to drive the muscle activation by multiple sensors combined together without the need of using an [AdnActivation](../utils/activation#adnactivation) node. In practice, having an AdnActivation node with multiple input sensors connected to the **activation** attribute of an AdnRibbonMuscle is equivalent to connecting those sensors directly to the activation list of that muscle.
 
 The activation layers contribute to the final activation of the muscle solver, where the first layer will always be the **activation** scalar attribute. Then, every value in the **activation list** array plug is applied on top taking into consideration the operator and the bypass flag. The resulting value is the global activation that the solver will use for the simulation, and it is written onto the read-only **output solver activation** attribute.
 
@@ -394,3 +394,10 @@ The operators available are:
 > [!NOTE]
 > - All operators will be evaluated from top to bottom (starting from the lowest index and ending on the last index used).
 > - The final value will be clamped in the range 0 to 1 to ensure that the solver activation is always normalized.
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
+

--- a/docs/houdini/solvers/simshape.md
+++ b/docs/houdini/solvers/simshape.md
@@ -275,7 +275,7 @@ AdnSimshape can emulate the behavior of facial muscles by computing the muscle a
 
 > [!NOTE = Activation Modes]
 > === Muscle Patches
-> The data in the AdonisFX Muscle Patches file in combination with the deformation status of the Deform Mesh are used to calculate the amount of activation at each vertex. The AMP file is the result of a Machine Learning process and can be generated following the steps presented [here](#generate-muscle-patches). The requirements for this mode to work are:
+> The data in the AdonisFX Muscle Patches file in combination with the deformation status of the Deform Mesh are used to calculate the amount of activation at each vertex. The AMP file is the result of a Machine Learning process and can be generated following the steps presented in the next section. The requirements for this mode to work are:
 >  - AdonisFX Muscle Patches file
 >  - Deform mesh
 >
@@ -363,3 +363,8 @@ The use of rest collider is recommended when the pre-roll simulation is not comp
 > - Colliders with high Level Of Detail will affect the simulation performance.
 > - Collider meshes must have the same number of vertices although it can be different from the number of vertices of the rest, deformed, animated and simulated meshes.
 
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/solvers/skin.md
+++ b/docs/houdini/solvers/skin.md
@@ -300,3 +300,10 @@ Once the AdnSkin SOP is created, it is possible to add and remove new targets to
     2. Remove it using the **X** button for that item.
     3. Alternatively, to remove all targets, click the **Clear** button of the *Targets* multiparm.
     4. Make sure to recook the AdnSkin at preroll start time for this change to take effect.
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
+

--- a/docs/houdini/tools/turbo_tool.md
+++ b/docs/houdini/tools/turbo_tool.md
@@ -81,6 +81,7 @@ Note that if any input is wrong or missing, the corresponding input text will tu
 > [!NOTE]
 > - Fascia and fat meshes must have the same topology for the AdnFat deformer to be created by AdnTurbo.
 > - AdnTurbo can also be executed via Python scripting. For more details, please refer to the [Turbo Script page](../scripts/turbo).
+> - For turbo to work correctly, the mummies have to have correct UV's.
 
 ## Result
 

--- a/docs/houdini/utils/activation.md
+++ b/docs/houdini/utils/activation.md
@@ -89,3 +89,10 @@ The *Inputs* attribute is presented as an array of 3 attributes which can be fou
   ![AdnActivation parameter template](../images/activation_parameter_template_00.png)
   <figcaption><b>Figure 3</b>: AdnActivation Parameter Template.</figcaption>
 </figure>
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
+

--- a/docs/houdini/utils/edge_evaluator.md
+++ b/docs/houdini/utils/edge_evaluator.md
@@ -57,3 +57,10 @@ The evaluator node can be used to drive the activations of an AdnSimshape SOP. T
   ![Edge Evaluator parameter template](../images/edge_evaluator_parameter_template_00.png)
   <figcaption><b>Figure 3</b>: Edge Evaluator Parameter Template.</figcaption>
 </figure>
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
+

--- a/docs/houdini/utils/locators.md
+++ b/docs/houdini/utils/locators.md
@@ -180,3 +180,10 @@ Three transform nodes will be required to create the AdnLocatorRotation. The cre
   ![AdnLocatorRotation parameter template general tab](../images/locator_rotation_parameter_template_00.png) 
   <figcaption><b>Figure 9</b>: AdnLocatorRotation Parameter Template.</figcaption>
 </figure>
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
+

--- a/docs/houdini/utils/remap.md
+++ b/docs/houdini/utils/remap.md
@@ -71,3 +71,10 @@ In the above setup we have the following characteristics:
   ![AdnRemap Parameter Template](../images/remap_parameter_template.png)
   <figcaption><b>Figure 2</b>: AdnRemap Attribute Editor.</figcaption>
 </figure>
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
+

--- a/docs/houdini/utils/sensors.md
+++ b/docs/houdini/utils/sensors.md
@@ -372,3 +372,10 @@ Three transforms will be required to create the AdnSensorRotation. To create an 
   ![AdnSensorRotation parameter template output tab](../images/sensor_rotation_parameter_template_04.png) 
   <figcaption><b>Figure 20</b>: AdnSensorRotation Parameter Template: Output.</figcaption>
 </figure>
+
+## Connections
+
+Connections in AdonisFX for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+  - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
+

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -58,7 +58,7 @@ To activate AdonisFX in Node-Locked Interactive mode:
       <figcaption><b>Figure 4</b>: Activation Retry Adding Product Key.</figcaption>
 </figure>
 
-  6. AdonisFX is activated. Restart your DCC or reload the plugin to start using all features from AdonisFX.
+  6. AdonisFX is activated. Restart your DCC to start using all features from AdonisFX.
 
 > [!NOTE]
 > - This activation mode requires access to the internet for activating licenses.

--- a/docs/maya/deformers/push.md
+++ b/docs/maya/deformers/push.md
@@ -1,6 +1,6 @@
 # AdnPush
 
-AdnPush is a Maya deformer designed to push a surface along the direction of its normals. This deformation can be applied outwards (i.e., the surface bulges and gains volume) or inwards (i.e., the surface shrinks and loses volume). This deformer is useful for refining meshes by increasing or decreasing their volume, as well as for modeling purposes. For example, a common use case is generating internal fascia geometry from skin geometry. Check [this section](../simple_setup#AdnPush) to see a simple setup of this.
+AdnPush is a Maya deformer designed to push a surface along the direction of its normals. This deformation can be applied outwards (i.e., the surface bulges and gains volume) or inwards (i.e., the surface shrinks and loses volume). This deformer is useful for refining meshes by increasing or decreasing their volume, as well as for modeling purposes. For example, a common use case is generating internal fascia geometry from skin geometry. Check [this section](../simple_setup#adnpush) to see a simple setup of this.
 
 ## How to use
 

--- a/docs/maya/scripts/io.md
+++ b/docs/maya/scripts/io.md
@@ -66,7 +66,7 @@ adnio.import_data(file_path, enabled_features)
 
 The first argument `file_path` is required and it is the full path to the JSON file containing a valid AdonisFX setup definition. The second argument `enabled_features` is optional and corresponds to a dictionary where keys are feature names and values are flags to determine if a feature has to be imported or bypassed (same format used for gathering data).
 
-Find more information about the use of the import feature in the [Import](tools/importer) page.
+Find more information about the use of the import feature in the [Import](../tools/importer) page.
 
 ## Export
 
@@ -79,7 +79,7 @@ adnio.export_data(file_path, enabled_features)
 
 The first argument `file_path` is required and it is the full path to the JSON file to export the data into. The second argument `enabled_features` is optional and corresponds to a dictionary where keys are feature names and values are flags to determine if a feature has to be exported or bypassed (same format used for gathering data).
 
-Find more information about the use of the export feature in the [Export](tools/exporter) page.
+Find more information about the use of the export feature in the [Export](../tools/exporter) page.
 
 ## Limitations
 

--- a/docs/maya/simple_setup.md
+++ b/docs/maya/simple_setup.md
@@ -104,7 +104,7 @@ With the Connection Editor opened, select the locator from the scene and press t
   <figcaption><b>Figure 10</b>: Connection Editor tool.</figcaption>
 </figure>
 
-When the elbow is flexed (and therefore the angle from the locator gets smaller) the muscle activation will get higher, simulating a much more realistic scenario.
+When the elbow is flexed (and therefore the angle from the locator gets smaller) the muscle activation increases, simulating a much more realistic scenario.
 
 To tweak additional parameters of the AdnMuscle deformer, check this [page](solvers/muscle).
 
@@ -133,7 +133,7 @@ To create the AdnRibbonMuscle deformer with some initial specialization, double-
   <figcaption><b>Figure 12</b>: AdnRibbonMuscle custom creation UI.</figcaption>
 </figure>
 
-In order to add attachment constraints to the ribbon muscle select the targets (joints, geometries or both), then the muscle with the AdnMuscle applied and finally press the ![add target](images/adn_add_target.png){style="width:4%"} button or *Add Targets* in the AdonisFX menu from the Edit Muscle submenu.
+In order to add attachment constraints to the ribbon muscle select the targets (joints, geometries or both), then the muscle with the AdnRibbonMuscle applied and finally press the ![add target](images/adn_add_target.png){style="width:4%"} button or *Add Targets* in the AdonisFX menu from the Edit Muscle submenu.
 
 Additionally, target geometries that have been added to an AdnRibbonMuscle deformer can also be used to define Slide On Geometry Constraints. This constraint type is recommended for muscles in the limbs of the character to better follow the animation.
 
@@ -303,7 +303,7 @@ Finally, the *Hard Constraints* map provides additional control for stronger att
 
 <figure markdown>
   ![Hard constraints weights paint](images/simple_setup_fat_02.png)
-  <figcaption><b>Figure 26</b>: Hard constraints weights paint.</figcaption>
+  <figcaption><b>Figure 26</b>: AdnFat weights painted for hard constraints.</figcaption>
 </figure>
 
 ## AdnSkin

--- a/docs/maya/solvers/muscle.md
+++ b/docs/maya/solvers/muscle.md
@@ -2,7 +2,7 @@
 
 AdnMuscle is a Maya deformer for fast, robust and easy-to-configure volumetric muscle simulation for digital assets. Thanks to the combination of internal (structural) and external (attachment and slide) constraints, this deformer can produce dynamics that allow the mesh to acquire the simulated characteristics of a muscle with realistic volume preservation, fibers activations to modulate the rigidity, and attachments properties to external objects to follow the global kinematics of the character.
 
-The influence these constraints have on the simulated mesh can be freely modified by painting them via the [AdonisFX Paint Tool](../tools#paint-tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the muscle's dynamics and behavior to a wide array of options.
+The influence these constraints have on the simulated mesh can be freely modified by painting them via the [AdonisFX Paint Tool](../tools/paint_tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the muscle's dynamics and behavior to a wide array of options.
 
 ### How To Use
 
@@ -180,7 +180,7 @@ To create an AdnMuscle, follow these steps:
 
 ## Paintable Weights
 
-In order to provide more artistic control, some key parameters of the muscle solver are exposed as paintable attributes in the deformer. The [AdonisFX Paint Tool](../tools#paint-tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
+In order to provide more artistic control, some key parameters of the muscle solver are exposed as paintable attributes in the deformer. The [AdonisFX Paint Tool](../tools/paint_tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
 
 | Name | Default | Description |
 | :--- | :------ | :---------- |
@@ -333,7 +333,7 @@ Not painting the fibers multiplier map will cause the muscle to contract uniform
 
 ### Activation Layers
 
-The activation layers allow to drive the muscle activation by multiple sensors combined together without the need of using an [AdnActivation](../utils#activation) node. In practice, having an AdnActivation node with multiple input sensors connected to the **activation** attribute of an AdnMuscle is equivalent to connecting those sensors directly to the activation list of that muscle.
+The activation layers allow to drive the muscle activation by multiple sensors combined together without the need of using an [AdnActivation](../utils/activation#adnactivation) node. In practice, having an AdnActivation node with multiple input sensors connected to the **activation** attribute of an AdnMuscle is equivalent to connecting those sensors directly to the activation list of that muscle.
 
 The activation layers contribute to the final activation of the muscle solver, where the first layer will always be the **activation** scalar attribute. Then, every value in the **activation list** array plug is applied on top taking into consideration the operator and the bypass flag. The resulting value is the global activation that the solver will use for the simulation, and it is written onto the read-only **output solver activation** attribute.
 

--- a/docs/maya/solvers/ribbon.md
+++ b/docs/maya/solvers/ribbon.md
@@ -2,7 +2,7 @@
 
 AdnRibbonMuscle is a Maya deformer for fast, robust and easy-to-configure muscle simulation on a surface. Thanks to the combination of internal (structural) and external (attachment and slide) constraints, this deformer can produce dynamics that allow the mesh to acquire the simulated characteristics of a ribbon with fibers activations to modulate the rigidity, and attachments to external objects to follow the global kinematics of the character.
 
-The influence these constraints have on the simulated mesh can be freely modified by painting them via the [AdonisFX Paint Tool](../tools#paint-tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the muscle's dynamics and behavior to a wide array of options.
+The influence these constraints have on the simulated mesh can be freely modified by painting them via the [AdonisFX Paint Tool](../tools/paint_tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the muscle's dynamics and behavior to a wide array of options.
 
 ### How To Use
 
@@ -176,7 +176,7 @@ Follow these steps to create an AdnRibbonMuscle deformer:
 
 ## Paintable Weights
 
-In order to provide more artistic control, some key parameters of the AdnRibbonMuscle solver are exposed as paintable attributes in the deformer. The [AdonisFX Paint Tool](../tools#paint-tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
+In order to provide more artistic control, some key parameters of the AdnRibbonMuscle solver are exposed as paintable attributes in the deformer. The [AdonisFX Paint Tool](../tools/paint_tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
 
 | Name | Default | Description |
 | :--- | :------ | :---------- |
@@ -318,7 +318,7 @@ Not painting the fibers multiplier map will cause the muscle to contract uniform
 
 ### Activation Layers
 
-The activation layers allow to drive the muscle activation by multiple sensors combined together without the need of using an [AdnActivation](../utils#activation) node. In practice, having an AdnActivation node with multiple input sensors connected to the **activation** attribute of an AdnRibbonMuscle is equivalent to connecting those sensors directly to the activation list of that muscle.
+The activation layers allow to drive the muscle activation by multiple sensors combined together without the need of using an [AdnActivation](../utils/activation#adnactivation) node. In practice, having an AdnActivation node with multiple input sensors connected to the **activation** attribute of an AdnRibbonMuscle is equivalent to connecting those sensors directly to the activation list of that muscle.
 
 The activation layers contribute to the final activation of the muscle solver, where the first layer will always be the **activation** scalar attribute. Then, every value in the **activation list** array plug is applied on top taking into consideration the operator and the bypass flag. The resulting value is the global activation that the solver will use for the simulation, and it is written onto the read-only **output solver activation** attribute.
 

--- a/docs/maya/solvers/simshape.md
+++ b/docs/maya/solvers/simshape.md
@@ -264,7 +264,7 @@ AdnSimshape can emulate the behavior of facial muscles by computing the muscle a
 
 > [!NOTE = Activation Modes]
 > === Muscle Patches
-> The data in the AdonisFX Muscle Patches file in combination with the deformation status of the Deform Mesh are used to calculate the amount of activation at each vertex. The AMP file is the result of a Machine Learning process and can be generated following the steps presented [here](#generate-muscle-patches). The requirements for this mode to work are:
+> The data in the AdonisFX Muscle Patches file in combination with the deformation status of the Deform Mesh are used to calculate the amount of activation at each vertex. The AMP file is the result of a Machine Learning process and can be generated following the steps presented in the next section. The requirements for this mode to work are:
 >  - AdonisFX Muscle Patches file
 >  - Deform mesh
 >

--- a/docs/maya/solvers/skin.md
+++ b/docs/maya/solvers/skin.md
@@ -2,7 +2,7 @@
 
 AdnSkin is a Maya deformer for fast, robust and easy-to-configure skin simulation for digital assets. Thanks to the combination of internal and external constraints, the deformer can produce dynamics that allow the skin mesh to realistically react to the deformations of internal tissues (e.g. muscles, fascia) over time.
 
-The influence these constraints have on the simulated mesh can be freely modified by painting them via the [AdonisFX Paint Tool](../tools#paint-tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the skin's dynamics and behavior to a wide array of options.
+The influence these constraints have on the simulated mesh can be freely modified by painting them via the [AdonisFX Paint Tool](../tools/paint_tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the skin's dynamics and behavior to a wide array of options.
 
 ### How To Use
 
@@ -175,7 +175,7 @@ The process to create an AdnSkin deformer is:
 
 ## Paintable Weights
 
-In order to provide more artistic control, some key parameters of the AdnSkin solver are exposed as paintable attributes in the deformer. The [AdonisFX Paint Tool](../tools#paint-tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
+In order to provide more artistic control, some key parameters of the AdnSkin solver are exposed as paintable attributes in the deformer. The [AdonisFX Paint Tool](../tools/paint_tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
 
 | Name | Default | Description |
 | :--- | :------ | :---------- |

--- a/docs/maya/tools/turbo_tool.md
+++ b/docs/maya/tools/turbo_tool.md
@@ -79,6 +79,7 @@ Note that if any input is wrong or missing, the corresponding input text will tu
 > - If multiple geometries or groups share the same name in different groups (e.g. group1|geo and group2|geo, group1|group3 and group2|group3), providing the full DAG path will be required.
 > - Fascia and fat meshes must have the same topology for the AdnFat deformer to be created by AdnTurbo.
 > - AdnTurbo can also be executed via Python scripting. For more details, please refer to the [Turbo Script page](../scripts/turbo).
+> - For turbo to work correctly, the mummies have to have correct UV's.
 
 ## Result
 

--- a/docs/maya/utils/sensors.md
+++ b/docs/maya/utils/sensors.md
@@ -120,7 +120,7 @@ An AdnSensorDistance will be in charge of computing, remapping and feeding activ
   <figcaption><b>Figure 6</b>: AdnSensorDistance used in a human model.</figcaption>
 </figure>
 
-There are two different methods of creating an AdnSensorDistance, depending if it is to be applied on an existing [AdnLocatorDistance](locators) or creating it alongside the sensor.
+There are two different methods of creating an AdnSensorDistance, depending if it is to be applied on an existing [AdnLocatorDistance](locators#adnlocatordistance) or creating it alongside the sensor.
 
  - If applying to an already existing AdnLocatorDistance:
 
@@ -246,7 +246,7 @@ An AdnSensorRotation will be in charge of computing, remapping and feeding activ
   <figcaption><b>Figure 12</b>: AdnSensorRotation used in a human model.</figcaption>
 </figure>
 
-There are two different methods of creating an AdnSensorRotation, depending if it is to be applied on an existing [AdnLocatorRotation](locators) or creating it alongside the sensor.
+There are two different methods of creating an AdnSensorRotation, depending if it is to be applied on an existing [AdnLocatorRotation](locators#adnlocatorrotation) or creating it alongside the sensor.
 
  - If applying to an already existing AdnLocatorRotation:
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,7 +2,7 @@
 
 ## Software
 
-- Maya 2022, 2023, 2024, 2025, 2026
+- Maya 2023, 2024, 2025, 2026
 - Houdini 20.0, 20.5, 21.0
 
 ## System Requirements
@@ -15,3 +15,4 @@
 > [!NOTE]
 > - AdonisFX may work with other CPU and RAM specifications.
 > - The list above represents the specifications that have been tested successfully.
+> - Internet connection is required for licensing only.


### PR DESCRIPTION
This pull request primarily updates and expands the documentation for AdonisFX's Houdini integration, focusing on clarifying unit handling, improving cross-application workflows, and providing consistent guidance on connecting node parameters. It also corrects and improves internal and external documentation links, and removes a deprecated tool from the navigation. The most significant changes are summarized below:

**Documentation Improvements and Clarifications:**

* Expanded the explanation of unit handling in `docs/faq.md`, detailing differences between Maya and Houdini, and providing guidance for correct scaling and simulation results when transferring assets between DCCs.
* Added a standardized "Connections" section to multiple Houdini SOP and solver documentation pages (`push.md`, `relax.md`, `skin_merge.md`, `fat.md`, `glue.md`, `muscle.md`), explaining the usage of detail and channel expressions for connecting node parameters and attributes. [[1]](diffhunk://#diff-59c7472a7015adce27a2c263a20fb5258a44551cbb67eb9799065e8e5b16c9dcR73-R78) [[2]](diffhunk://#diff-ef0935813d48869f5a9a3c0b8de98e4d271cf93acc6f8c34b3d0a7c317b5dec3R86-R91) [[3]](diffhunk://#diff-b76d0efd4ed60df0ae4df1b6f2d22c033fd801e0e34b6dc7c3f7c5ea629831b6R114-R119) [[4]](diffhunk://#diff-e21e3e8176728d439dbe617464d135a6daa485399debbaf2645219ba1802e504R209-R215) [[5]](diffhunk://#diff-5585b2b9938665a8ec309ffc6964f0ad7a36a9efd75011a6d11a7a70d58f0dcfR266-R271) [[6]](diffhunk://#diff-3dda3d6e5ce91503430cb0b9c7b3499610c00e6f814107adeb3266b2341ab08bR409-R415)
* Added a note about potential point ID reordering in `docs/houdini/solvers/glue.md` to clarify output behavior when merging geometries.

**Link and Reference Corrections:**

* Fixed and standardized internal documentation links, including anchor references for sections and pages in `push.md`, `muscle.md`, `ribbon.md`, and `simple_setup.md`. [[1]](diffhunk://#diff-59c7472a7015adce27a2c263a20fb5258a44551cbb67eb9799065e8e5b16c9dcL3-R3) [[2]](diffhunk://#diff-3dda3d6e5ce91503430cb0b9c7b3499610c00e6f814107adeb3266b2341ab08bL340-R340) [[3]](diffhunk://#diff-b9a6ca1d9c222ab055d633dd4c5eda50ccc2fa2cb168f32ddb708a6f6cb0ed40L333-R333) [[4]](diffhunk://#diff-3e33e2138a12abe35dc92b613004b407dd7baf204521c74f268afea9bf3ab726L120-R126)
* Updated links to the Import and Export tool documentation in `docs/houdini/scripts/io.md` for correct navigation. [[1]](diffhunk://#diff-7af8674ee50a61aacb7ec2523a6124973e734a5a76bcc13287ee71f8e8ebad4fL77-R77) [[2]](diffhunk://#diff-7af8674ee50a61aacb7ec2523a6124973e734a5a76bcc13287ee71f8e8ebad4fL93-R93)
* Updated references to activation utility documentation for consistency and accuracy. [[1]](diffhunk://#diff-3dda3d6e5ce91503430cb0b9c7b3499610c00e6f814107adeb3266b2341ab08bL394-R394) [[2]](diffhunk://#diff-b9a6ca1d9c222ab055d633dd4c5eda50ccc2fa2cb168f32ddb708a6f6cb0ed40L382-R382)

**Navigation and Tooling:**

* Removed the deprecated `AdnLearnMusclePatches` tool from the Houdini documentation index.

These updates enhance clarity, consistency, and usability of the AdonisFX documentation for Houdini users.