### PR TITLE
Release v2.0.1 (Maya and Houdini): fix in EvalDeltaTime

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,7 @@
 2026-06-02
 
 ### Bug Fixes
-- Fixed a bug that was causing subframe evaluations to be treated as positive integer frame jumps. *AdonisFX-3193*.
+- Fixed a bug that was causing subframe evaluations to default to one frame timestep instead of the evaluated subframe timestep. *AdonisFX-3193*.
 
 ## Version 2.0.0
 2026-03-04

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Version 2.0.1
+2026-06-02
+
+### Bug Fixes
+- Fixed a bug that was causing subframe evaluations to be treated as positive integer frame jumps. *AdonisFX-3193*.
+
 ## Version 2.0.0
 2026-03-04
 


### PR DESCRIPTION

This pull request updates the release notes to document a recent bug fix in version 2.0.1. The change clarifies a resolved issue with subframe evaluations defaulting to the wrong timestep.

Release notes update:

* Added a new section for version 2.0.1 (2026-06-02) in `docs/release_notes.md`, documenting a bug fix where subframe evaluations were defaulting to one frame timestep instead of the evaluated subframe timestep.