### PR TITLE
#385 Replaced AdonisFX occurrences with Adonis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # adonisfx_docs
-AdonisFX Documentation
+Adonis Documentation
 
 ## How To Compile
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,15 +4,15 @@
 
 ### How can I simulate muscles?
 
-AdonisFX provides two solvers for muscle simulation. The use of one or the other depends on the necessity of simulating volume preservation. Muscles with volume preservation can be simulated with **AdnMuscle** deformer, while **AdnRibbonMuscle** is for planar muscles. For more information about a simple setup, please check their respective sections in *A Simple Setup* page.
+Adonis provides two solvers for muscle simulation. The use of one or the other depends on the necessity of simulating volume preservation. Muscles with volume preservation can be simulated with **AdnMuscle** deformer, while **AdnRibbonMuscle** is for planar muscles. For more information about a simple setup, please check their respective sections in *A Simple Setup* page.
 
 ### How can I add activation to the muscles?
 
-In order to add activation to the muscles it is necessary to define the fibers direction. This can be achieved by: first, painting the tendon weights to generate an initial estimation of fibers direction; and second, combing the fibers to customize the final fibers flow along the surface. Once the muscle has a valid fiber direction at each vertex, then the activation attribute triggers the contraction of the fibers. Ultimately, the level of activation can be modulated by an AdonisFX sensor to connect the contraction of the muscle to the animation of the rig. For more information about connecting sensors to muscles, please check the **Connect Sensors** section in **A Simple Setup** page.
+In order to add activation to the muscles it is necessary to define the fibers direction. This can be achieved by: first, painting the tendon weights to generate an initial estimation of fibers direction; and second, combing the fibers to customize the final fibers flow along the surface. Once the muscle has a valid fiber direction at each vertex, then the activation attribute triggers the contraction of the fibers. Ultimately, the level of activation can be modulated by an Adonis sensor to connect the contraction of the muscle to the animation of the rig. For more information about connecting sensors to muscles, please check the **Connect Sensors** section in **A Simple Setup** page.
 
 ### How can I combine multiple activation values?
 
-Multiple activation values from different AdonisFX sensors (AdnSensorPosition, AdnSensorDistance, AdnSensorRotation) can be combined into a single value using the **AdnActivation** node. This node allows overriding, adding, subtracting, multiplying and dividing multiple input activations to compute a single output value. For more details please refer to the **AdnActivation** page.
+Multiple activation values from different Adonis sensors (AdnSensorPosition, AdnSensorDistance, AdnSensorRotation) can be combined into a single value using the **AdnActivation** node. This node allows overriding, adding, subtracting, multiplying and dividing multiple input activations to compute a single output value. For more details please refer to the **AdnActivation** page.
 
 ### How can I add volume gain to the muscles?
 
@@ -20,7 +20,7 @@ The *Volume Ratio* attribute of an AdnMuscle allows to simulate volume gain (vol
 
 ### How can I simulate interaction between muscles?
 
-AdonisFX provides two ways of simulating muscle-to-muscle interactions:
+Adonis provides two ways of simulating muscle-to-muscle interactions:
 
 - Using the AdnMuscle deformer. The AdnMuscle deformer allows configuring geometry targets to simulate external constraints (e.g. attachment to geometry and slide on geometry constraints). A simulated muscle can be assigned as a target to another simulated muscle in the same way as any other geometry target would be added (e.g. bones). Detailed instructions for adding and removing targets can be found in the **Advanced** section of the **AdnMuscle** page.
 
@@ -57,27 +57,27 @@ You can use **AdnSimshape** deformer. This deformer allows to reproduce the elas
 
 The AdnSimshape deformer allows to add muscle activation in two ways:
 
- - Providing a deform mesh together with an AdonisFX Muscle Patches file previously generated using the Learn Muscle Patches tool.
+ - Providing a deform mesh together with an Adonis Muscle Patches file previously generated using the Learn Muscle Patches tool.
  - Ingesting the activation values directly into the AdnSimshape node. These activation values can be computed from the rest mesh and the deform mesh using the AdnEdgeEvaluator node (for more information visit the **AdnEdgeEvaluator** page).
 
 More details can be found in the **Add muscle activations** section in **A Simple Setup** page.
 
 ### How can I use Machine Learning to add muscle activations to AdnSimshape?
 
-To add muscle activation via Machine Learning, the Learn Muscle Patches tool has to be used to generate the AdonisFX Muscle Patches file. The requirements for this tool are a neutral mesh (facial geometry at rest) and a set of target meshes with deformation representing all facial expressions to drive the learning. Go to the **Generate Muscle Patches** section in the **AdnSimshape** page to know more.
+To add muscle activation via Machine Learning, the Learn Muscle Patches tool has to be used to generate the Adonis Muscle Patches file. The requirements for this tool are a neutral mesh (facial geometry at rest) and a set of target meshes with deformation representing all facial expressions to drive the learning. Go to the **Generate Muscle Patches** section in the **AdnSimshape** page to know more.
 
-### Can I add muscle activations to AdnSimshape without an AdonisFX Muscle Patches file?
+### Can I add muscle activations to AdnSimshape without an Adonis Muscle Patches file?
 
-AdnSimshape allows to add muscle activation alternatively without the need for the AdonisFX Muscle Patches file. To do this, the activation values must be ingested directly into the AdnSimshape node. These activation values can be computed from the rest mesh and the deform mesh using the AdnEdgeEvaluator tool. Read how to drive the activations of AdnSimshape using AdnEdgeEvaluator in the dedicated **AdnEdgeEvaluator** page.
+AdnSimshape allows to add muscle activation alternatively without the need for the Adonis Muscle Patches file. To do this, the activation values must be ingested directly into the AdnSimshape node. These activation values can be computed from the rest mesh and the deform mesh using the AdnEdgeEvaluator tool. Read how to drive the activations of AdnSimshape using AdnEdgeEvaluator in the dedicated **AdnEdgeEvaluator** page.
 
-### For what units is AdonisFX designed?
+### For what units is Adonis designed?
 
-The AdonisFX simulation engine works in centimeters. 
+The Adonis simulation engine works in centimeters. 
 
-In Maya, the unit system also works internally in centimeters, disregarding any preferences set for the viewport. AdonisFX then works in centimeters in conjunction with Maya, disregarding any working units set in the Maya preferences. In Houdini, the scene units are generally presented in meters. Given that AdonisFX works in centimeters internally, in some cases, the mesh has to be scaled accordingly to represent the right scaling. This may be one of the contributing factors to incorrect looking simulations when comparing to Maya.
+In Maya, the unit system also works internally in centimeters, disregarding any preferences set for the viewport. Adonis then works in centimeters in conjunction with Maya, disregarding any working units set in the Maya preferences. In Houdini, the scene units are generally presented in meters. Given that Adonis works in centimeters internally, in some cases, the mesh has to be scaled accordingly to represent the right scaling. This may be one of the contributing factors to incorrect looking simulations when comparing to Maya.
 
 For example in Maya, is typical to model creatures 10 times smaller in order to avoid precision issues. Imagine the example of a creature that is supposed to be 1.7 meters tall (170 Maya units). Then in Maya to avoid precision issues, this creature may be modeled to be 17 centimeters tall (17 Maya units).
-In this case you can adjust the simulation for this scaling factor by applying the AdonisFX Space Scale attribute to 10. This will ensure that AdonisFX will scale everything internally so that the simulation of the 17 units creature will look like if it was actually 170 units tall. Similar criteria can be applied to Houdini, however, it is still advisable to check the scaling of the characters when transferring between DCCs.
+In this case you can adjust the simulation for this scaling factor by applying the Adonis Space Scale attribute to 10. This will ensure that Adonis will scale everything internally so that the simulation of the 17 units creature will look like if it was actually 170 units tall. Similar criteria can be applied to Houdini, however, it is still advisable to check the scaling of the characters when transferring between DCCs.
 
 ### How can I transfer the results of skin simulation to the final mesh?
 Make use of the **AdnSkinMerge** deformer to blend animated and simulated meshes into a single final mesh. Create and configure the node providing the final mesh and add the simulation and animation meshes. Then you only need to paint the blend weight to define the influence of the simulated mesh targets over the animated ones. You can find more information in the **AdnSkinMerge** page.
@@ -90,7 +90,7 @@ For muscles, controlling the area in which the muscle should activate and bulge 
 
 ### Can I mirror the muscles setup?
 
-Yes, a Python script is provided to transfer the muscle setup of an asset from left to right and vice versa. This script includes the mirroring of AdonisFX muscles, locators and sensors. It mirrors not only the scalar attributes and paintable maps, but also the connections and dependencies between all of them. Know more about the mirroring in the **Mirror** page.
+Yes, a Python script is provided to transfer the muscle setup of an asset from left to right and vice versa. This script includes the mirroring of Adonis muscles, locators and sensors. It mirrors not only the scalar attributes and paintable maps, but also the connections and dependencies between all of them. Know more about the mirroring in the **Mirror** page.
 
 ### How can I generate the fascia geometry using Maya tools?
 
@@ -119,9 +119,9 @@ The second approach is to use nCloth to apply a pressured simulation. This solut
 
 As a final step for both approaches, you may want to smooth the resulting fascia geometry with sculpting tools to polish the final result.
 
-### How can I upgrade a Maya scene from AdonisFX v1 to v2?
+### How can I upgrade a Maya scene from Adonis v1 to v2?
 
-Go to AdonisFX menu > Utils and press *Upgrade v1.x To v2.x*. This option performs an upgrade to all AdonisFX solvers to make v1.x rigs compatible with v2.x. This upgrade affects the painted values in the maps that are affected by the *Maps Remap Mode* attribute added in v2.0.0 to all solvers (i.e., shape preservation, attachments and sliding in muscle solver, uber constraints in skin solver). Due to how this remapping modifies how the painted values from the plugs are transferred to the solver, this utility updates those values in order to get simulation results as consistent as possible with v1.x.
+Go to Adonis menu > Utils and press *Upgrade v1.x To v2.x*. This option performs an upgrade to all Adonis solvers to make v1.x rigs compatible with v2.x. This upgrade affects the painted values in the maps that are affected by the *Maps Remap Mode* attribute added in v2.0.0 to all solvers (i.e., shape preservation, attachments and sliding in muscle solver, uber constraints in skin solver). Due to how this remapping modifies how the painted values from the plugs are transferred to the solver, this utility updates those values in order to get simulation results as consistent as possible with v1.x.
 
 Additionally, since the *Concrete* material has been deprecated, this upgrade script also checks whether any nodes in the scene are using an invalid material. If an invalid material is found, it will be automatically replaced with the default material.
 
@@ -129,7 +129,7 @@ As a final step to support the addition of the *currentTime* plug in AdnSkinMerg
 
 ### How can I reconnect the time to the *currentTime* plug in Maya if I had accidentally broken the connection?
 
-Go to AdonisFX menu > Utils and press *Reconnect Current Time*. This option will search for all AdonisFX nodes in the scene with a *currentTime* plug and connect the *time1.outTime* plug to it.
+Go to Adonis menu > Utils and press *Reconnect Current Time*. This option will search for all Adonis nodes in the scene with a *currentTime* plug and connect the *time1.outTime* plug to it.
 This is necessary to ensure a correct cooking of the nodes.
 
 ## Cross-DCC Support
@@ -144,33 +144,33 @@ Yes. Each deformer chain affecting a single geometry must be enclosed in a defor
 A deformable region is defined using two SOP Null nodes with a specific naming convention:
 - Start node: `ADN_IN_<geo_name>`.
 - End node: `ADN_OUT_<geo_name>`.
-All AdonisFX deformers affecting `geo_name` should be placed between these nodes.
+All Adonis deformers affecting `geo_name` should be placed between these nodes.
 This structure allows components such as the API to correctly identify which SOP nodes affect which geometries, ensuring smooth transfer to other DCCs.
 
 ### Do geometries need preprocessing in Houdini?
-Yes. Before using AdonisFX:
+Yes. Before using Adonis:
 - Geometry must be unpacked.
 - PolySoup primitives are not supported and should be avoided.
 
-### Does AdonisFX in Houdini support transforms?
-No. AdonisFX operates purely in geometry (SOP) space. Any transforms applied at the object level (world transform matrices) are not supported. Make sure to apply transforms directly to point positions before processing geometry with AdonisFX.
+### Does Adonis in Houdini support transforms?
+No. Adonis operates purely in geometry (SOP) space. Any transforms applied at the object level (world transform matrices) are not supported. Make sure to apply transforms directly to point positions before processing geometry with Adonis.
 
 ## Debugging
 
 ### How can I change the logger level?
 
-AdonisFX Logger has different levels of execution: (0) Debug, (1) Info, (2) Warning, (3) Error. The level is determined by an environment variable `ADN_LOGGER_LEVEL`. If not defined, AdonisFX Logger Level is set to Info by default. This allows the system to print Info, Warning and Error messages to the console. If more verbosity is required, it is possible to modify the level to Debug. For that, the environment variable `ADN_LOGGER_LEVEL` has to be set to `0`. Note that for this change to take effect, the AdonisFX plugin must be reloaded.
+Adonis Logger has different levels of execution: (0) Debug, (1) Info, (2) Warning, (3) Error. The level is determined by an environment variable `ADN_LOGGER_LEVEL`. If not defined, Adonis Logger Level is set to Info by default. This allows the system to print Info, Warning and Error messages to the console. If more verbosity is required, it is possible to modify the level to Debug. For that, the environment variable `ADN_LOGGER_LEVEL` has to be set to `0`. Note that for this change to take effect, the Adonis plugin must be reloaded.
 
 ## Performance
 
-### How can I control the multithreading of AdonisFX solvers?
+### How can I control the multithreading of Adonis solvers?
 
-AdonisFX nodes use multithreading based on a threshold that determines the minimum number of elements required for parallel processing. If the number of elements to process exceeds this threshold, multithreading will be applied, otherwise, the code will execute sequentially. This threshold is set to `16` by default, but can be adjusted by modifying the value of the `ADN_MIN_PARALLEL_SIZE` environment variable. Modify this value carefully, as it can improve performance in some cases but may also reduce it depending on your CPU.
+Adonis nodes use multithreading based on a threshold that determines the minimum number of elements required for parallel processing. If the number of elements to process exceeds this threshold, multithreading will be applied, otherwise, the code will execute sequentially. This threshold is set to `16` by default, but can be adjusted by modifying the value of the `ADN_MIN_PARALLEL_SIZE` environment variable. Modify this value carefully, as it can improve performance in some cases but may also reduce it depending on your CPU.
 
 ## Licensing
 
-### Does AdonisFX require internet access?
-The use of AdonisFX itself does not require access to the internet but the licensing system does. In node-locked licenses, the workstation needs connection to the internet to validate the activation on plug-in load at least every 19 days. After that, the product can be used without internet connection. In floating licenses, it is the server that will need to connect to the internet at least every 19 days to validate the activation, meaning that users' workstations or nodes on farms do not need internet access.
+### Does Adonis require internet access?
+The use of Adonis itself does not require access to the internet but the licensing system does. In node-locked licenses, the workstation needs connection to the internet to validate the activation on plug-in load at least every 19 days. After that, the product can be used without internet connection. In floating licenses, it is the server that will need to connect to the internet at least every 19 days to validate the activation, meaning that users' workstations or nodes on farms do not need internet access.
 
 ### Can I activate the node-locked licenses offline?
 No, node-locked licensing requires internet access to activate. Check the [licensing](licensing#node-locked-licensing) page for more information.
@@ -181,11 +181,11 @@ No, floating licensing requires internet access to activate the server. To be mo
 ### Can I use my node-locked license on more than one machine?
 It depends on the purchased product plan. For Indie licenses, only one activation is allowed. To be able to move the license to a different machine, you will need to deactivate the license and reactivate it on the newly configured machine. Please, contact support if that is your case. For Solo licenses, up to two activations are allowed. This means that you can activate your product key in two different machines. For more flexibility and no hardware specific licensing restriction you should purchase floating licenses.
 
-### How can I switch between node-locked licensing and floating licensing inside of AdonisFX?
+### How can I switch between node-locked licensing and floating licensing inside of Adonis?
 You can use the environment variable `ADN_LICENSE_MODE` set to `0` for node-locked licensing and `ADN_LICENSE_MODE` set to `1` for floating licensing. The license gets verified only once when the plug-in is loaded. This means that if a change like this one needs to be applied, then the application has to be restarted to load the plug-in again from a new process.
 
 ### What do I need to be able to use floating licensing?
-First of all, the licensing server has to be installed, configured and activated previously (check this [section](licensing#floating-licensing)). Then, the client machine(s) on which AdonisFX will be used have to be configured to allow them to connect to the server to request leases. The configuration simply requires to set a few environment variables: `ADN_LICENSE_MODE` to `1`; and `ADN_LICENSE_SERVER` and `ADN_LICENSE_SERVER_BATCH` to the IP address and port (e.g. `127.0.0.1:13`) of the interactive and batch floating server respectively.
+First of all, the licensing server has to be installed, configured and activated previously (check this [section](licensing#floating-licensing)). Then, the client machine(s) on which Adonis will be used have to be configured to allow them to connect to the server to request leases. The configuration simply requires to set a few environment variables: `ADN_LICENSE_MODE` to `1`; and `ADN_LICENSE_SERVER` and `ADN_LICENSE_SERVER_BATCH` to the IP address and port (e.g. `127.0.0.1:13`) of the interactive and batch floating server respectively.
 
 ### Can I move the license server to a different machine?
 Yes. This process requires you to deactivate it and then activate it on the new machine. For more information visit the [licensing](licensing#activate-server) page or contact support.
@@ -198,4 +198,4 @@ You can find and modify when leases are dropped inside of the `TurboFloatServer-
 For more information visit the [licensing](licensing#install-server) page or visit this [link](https://wyday.com/limelm/help/turbofloat-server/).
 
 ### I can't connect to my licensing server for floating licensing. What should I do?
-Make sure that your firewall configuration allows the connection and try using the `ping` command to check the connectivity. If the connection is valid but AdonisFX can't load, please contact support.
+Make sure that your firewall configuration allows the connection and try using the `ping` command to check the connectivity. If the connection is valid but Adonis can't load, please contact support.

--- a/docs/houdini/api.md
+++ b/docs/houdini/api.md
@@ -3,10 +3,10 @@
 ### Experimental Python API
 
 > [!NOTE]
-> - This API is experimental, and will be subject to changes in following versions of AdonisFX.
+> - This API is experimental, and will be subject to changes in following versions of Adonis.
 > - The use of this API in production applications is not supported.
 
-An experimental Python API has been developed to allow Technical Directors to implement custom Python scripts for exporting and rebuilding AdonisFX rigs programmatically.
+An experimental Python API has been developed to allow Technical Directors to implement custom Python scripts for exporting and rebuilding Adonis rigs programmatically.
 
 This API enables users to:
 - Extract the setup from an existing rig in Houdini.
@@ -15,15 +15,15 @@ This API enables users to:
 
 As this API is still under active development, please do not hesitate to send an email to **adonis.support@inbibo.co.uk** to provide feedback and/or feature requests. The support and development teams will work together to incorporate user feedback and refine the implementation.
 
-The API can be found in `AdonisFX/python/adn/api/adnx.py`.
+The API can be found in `Adonis/python/adn/api/adnx.py`.
 The definitions can be imported with `from adn.api.adnx import *`.
 
 Since the method definitions may change before the API becomes production-ready, here are some examples showing how to use the current experimental Python API for Houdini. Similar methods can be found directly in the `adnx.py` file.
 
 1. How to create a rig instance with Houdini as the host: `rig = AdnRig(AdnHost.kHoudini)`.
 2. How to set the context in which the rig information will be gathered or created: `rig.setContext("/obj/geo1")`.
-3. How to create an AdonisFX rig component and add it to the rig (e.g. an AdnMuscle inside the rig): `muscle = AdnMuscle(rig)` and `rig.addSolver(muscle)`.
-4. How to gather data from an existing AdonisFX scene to populate the rig component entry (assuming AdnMuscle1 exists in the Houdini scene): `muscle.fromNode("AdnMuscle1")`.
+3. How to create an Adonis rig component and add it to the rig (e.g. an AdnMuscle inside the rig): `muscle = AdnMuscle(rig)` and `rig.addSolver(muscle)`.
+4. How to gather data from an existing Adonis scene to populate the rig component entry (assuming AdnMuscle1 exists in the Houdini scene): `muscle.fromNode("AdnMuscle1")`.
 5. How to get the dictionary containing the extracted data: `data = muscle.getData()`.
 6. How to populate the rig component from a dictionary that contains all required entries: `muscle.fromDict(data)`. The required dictionary formatting can be found in the `__init__` methods of the `AdnMuscleBase` and `AdnMuscle` classes. Modifying dictionary entries allows users to update or rebuild rigs with custom values.
 7. How to update an existing rig component in the scene after modifying its values: `muscle.update()`. This method assumes that the target AdnMuscle already exists in the scene.
@@ -31,9 +31,9 @@ Since the method definitions may change before the API becomes production-ready,
 9. How to define the execution order when extracting data from an existing scene: `rig.buildExecutionOrder()`. With an already configured scene, this deduces the correct reconstruction order required to preserve deformation and node dependency chain.
 10. How to clear a specific rig component from the scene: `muscle.clear()`.
 
-All other methods can be found in the `AdonisFX/python/adn/api/adnx.py` file.
+All other methods can be found in the `Adonis/python/adn/api/adnx.py` file.
 
-The API is the base foundation for the Import/Export tools of AdonisFX. Below is an example of exported rig data in a .json file:
+The API is the base foundation for the Import/Export tools of Adonis. Below is an example of exported rig data in a .json file:
 
 <figure markdown>
   ![Houdini API Json example](images/houdini_api_json_example.png)
@@ -49,7 +49,7 @@ Each geometry to be deformed must be separated and encapsulated in a deformable 
 The `<geo_name>` should match the expected shape name counterpart in Maya.
 
 To ease the process of separating geometries, use the utility:
-- *AdonisFX* > *Utils* > *Separate Geometries*
+- *Adonis* > *Utils* > *Separate Geometries*
 
 This tool works when there is a valid piece attribute (path, name, or muscle_id) on the geometry stream.
 
@@ -63,10 +63,10 @@ This tool works when there is a valid piece attribute (path, name, or muscle_id)
 > - Data such as "geometryAttachments" are represented using the name without the `Shape` suffix. This is also important for interoperability between DCCs.
 > - A context must be defined in Houdini using the `rig.setContext("/obj/geo1")` method. This allows the API to know from which geometry context to extract data and where to reconstruct the rig.
 > - Rig components in Houdini must live directly inside the geometry node. Encapsulating components inside subnetworks (for example placing AdnMuscle nodes in a subnetwork) is not supported.
-> - Exported connections between AdonisFX nodes may differ depending on the DCC. This is expected due to differences between DCC applications. However, the rig will be correctly reconstructed when imported into any supported target DCC.
+> - Exported connections between Adonis nodes may differ depending on the DCC. This is expected due to differences between DCC applications. However, the rig will be correctly reconstructed when imported into any supported target DCC.
 
 ### Limitations
 
-- The API does not support subnetworks inside of the Geometry context. This means that all AdonisFX SOP nodes (and any other SOP nodes containing geometry required by the AdonisFX rig) must exist at the same level within the Geometry context (e.g., */obj/geo1*).
+- The API does not support subnetworks inside of the Geometry context. This means that all Adonis SOP nodes (and any other SOP nodes containing geometry required by the Adonis rig) must exist at the same level within the Geometry context (e.g., */obj/geo1*).
 - Nodes used to drive attachment to transform or slide on segment constraints (e.g. null, joint or rivet nodes) must live in the */obj* context.
 - KineFX joint transforms are not supported.

--- a/docs/houdini/deformers/push.md
+++ b/docs/houdini/deformers/push.md
@@ -7,7 +7,7 @@ AdnPush is a Houdini SOP designed to push a surface along the direction of its n
 The AdnPush SOP is easy to create and configure in Houdini. It only requires a mesh to apply the node to. Following the example mentioned above, this mesh would be the skin geometry at rest.
 
 1. Go to the geometry context of the rig containing the geometry to apply the deformer to.
-2. Press TAB and navigate to the submenu AdonisFX > Deformers to find the AdnPush ![Push button](../../images/adn_push.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Deformers to find the AdnPush ![Push button](../../images/adn_push.png){style="width:4%"} SOP type.
 3. Create it and connect the geometry to the input.
 4. Modify the value of the *Push Length* parameter to see the result of the push deformation. Check the [Attributes](push#attributes) section to customize their configuration.
 
@@ -39,7 +39,7 @@ The AdnPush SOP is easy to create and configure in Houdini. It only requires a m
 > - All maps parameters are disabled in the Maps tab because the attribute names are fixed to drive specific functionalities of the solver.
 > - Fixed point attribute names also ensure compatibility with the API.
 > - To copy the map names of the disabled attributes for painting (using an attribute paint node) right click on the disabled map attribute parameter, press "Copy Parameter", select the attribute paint node and on the attribute name entry right click and press "Paste Values". This allows to easily copy the attribute name for painting.
-> - The *Make Paintable* utility provided in the AdonisFX menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnPush SOP.
+> - The *Make Paintable* utility provided in the Adonis menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnPush SOP.
 > - If a point attribute on the geostream does not match the naming convention exposed in the node, use an "Attribute Rename" node to rename the attribute to match the expected naming convention.
 
 ## Parameter Template
@@ -69,10 +69,10 @@ To provide more control, the AdnPush SOP includes two paintable attributes.
 </figure>
 
 > [!NOTE]
-> To tweak the point attributes of an AdnPush SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnPush SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnPush node.
+> To tweak the point attributes of an AdnPush SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnPush SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnPush node.
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/deformers/relax.md
+++ b/docs/houdini/deformers/relax.md
@@ -7,7 +7,7 @@ AdnRelax is a Houdini SOP designed to smooth creases and correct over-compressio
 The AdnRelax SOP is easy to create and configure in Houdini. It only requires the mesh to apply the relaxation onto. Typically, this mesh would be the simulated fascia or skin.
 
 1. Go to the geometry context of the rig containing the geometry to apply the deformer to.
-2. Press TAB and navigate to the submenu AdonisFX > Deformers to find the AdnRelax ![Relax button](../../images/adn_relax.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Deformers to find the AdnRelax ![Relax button](../../images/adn_relax.png){style="width:4%"} SOP type.
 3. Create it and connect the geometry to the input.
 4. Increase the number of iterations to see the effect of the deformation. Check the [Attributes](relax#attributes) section to customize their configuration.
 
@@ -49,7 +49,7 @@ The AdnRelax SOP is easy to create and configure in Houdini. It only requires th
 > - All maps parameters are disabled in the Maps tab because the attribute names are fixed to drive specific functionalities of the solver.
 > - Fixed point attribute names also ensure compatibility with the API.
 > - To copy the map names of the disabled attributes for painting (using an attribute paint node) right click on the disabled map attribute parameter, press "Copy Parameter", select the attribute paint node and on the attribute name entry right click and press "Paste Values". This allows to easily copy the attribute name for painting.
-> - The *Make Paintable* utility provided in the AdonisFX menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnRelax SOP.
+> - The *Make Paintable* utility provided in the Adonis menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnRelax SOP.
 > - If a point attribute on the geostream does not match the naming convention exposed in the node, use an "Attribute Rename" node to rename the attribute to match the expected naming convention.
 
 ## Parameter Template
@@ -82,10 +82,10 @@ To provide more control, some key parameters of the AdnRelax SOP are exposed as 
 </figure>
 
 > [!NOTE]
-> To tweak the point attributes of an AdnRelax SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnRelax SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnRelax node.
+> To tweak the point attributes of an AdnRelax SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnRelax SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnRelax node.
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/deformers/skin_merge.md
+++ b/docs/houdini/deformers/skin_merge.md
@@ -15,7 +15,7 @@ To create an AdnSkinMerge SOP within a Houdini scene, the following inputs must 
 The process to create an AdnSkinMerge SOP is:
 
 1. Go to the geometry context of the rig containing the geometry to apply the solver onto.
-2. Press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnSkinMerge ![SkinMerge button](../../images/adn_skin_merge.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Solvers to find the AdnSkinMerge ![SkinMerge button](../../images/adn_skin_merge.png){style="width:4%"} SOP type.
 3. Create it and connect the geometry to the input.
 4. Add the animation and simulation meshes to the *Anim List* and *Sim List* multiparms respectively exposed in the *Targets* tab. Take into consideration the following requirements:
     - Add a mesh by increasing the number of entries in the multiparm and providing the object path of the geometry to the new entry.
@@ -32,7 +32,7 @@ The process to create an AdnSkinMerge SOP is:
 
 <figure style="width: 75%;" markdown>
   ![AdnSkinMerge example of network with attribpaint](../images/skin_merge_net_example.png) 
-  <figcaption><b>Figure 1</b>: Example of AdnSkinMerge network. The attribpaint node has to be placed prior to the AdnSkinMerge SOP. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 1</b>: Example of AdnSkinMerge network. The attribpaint node has to be placed prior to the AdnSkinMerge SOP. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 Once the AdnSkinMerge SOP is created, the input meshes (animation mesh list, simulation mesh list or both) can be modified:
@@ -78,7 +78,7 @@ Once the AdnSkinMerge SOP is created, the input meshes (animation mesh list, sim
 > - All maps parameters are disabled in the Maps tab because the attribute names are fixed to drive specific functionalities of the solver.
 > - Fixed point attribute names also ensure compatibility with the API.
 > - To copy the map names of the disabled attributes for painting (using an attribute paint node) right click on the disabled map attribute parameter, press "Copy Parameter", select the attribute paint node and on the attribute name entry right click and press "Paste Values". This allows to easily copy the attribute name for painting.
-> - The *Make Paintable* utility provided in the AdonisFX menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnSkinMerge SOP.
+> - The *Make Paintable* utility provided in the Adonis menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnSkinMerge SOP.
 > - If a point attribute on the geostream does not match the naming convention exposed in the node, use an "Attribute Rename" node to rename the attribute to match the expected naming convention.
 
 ## Parameter Template
@@ -110,10 +110,10 @@ Once the AdnSkinMerge SOP is created, the input meshes (animation mesh list, sim
 </figure>
 
 > [!NOTE]
-> To tweak the point attributes of an AdnSkinMerge SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSkinMerge SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSkinMerge node.
+> To tweak the point attributes of an AdnSkinMerge SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSkinMerge SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSkinMerge node.
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/scripts/io.md
+++ b/docs/houdini/scripts/io.md
@@ -2,25 +2,25 @@
 
 In `adn.scripts.houdini.adnio` module, a set of Python functions are provided to allow users to:
 
-- Gather the AdonisFX nodes setup from the scene.
-- Clear the scene by removing all AdonisFX nodes and dependent nodes.
-- Build the AdonisFX setup in the scene from a dictionary.
-- Import AdonisFX setup from a JSON file.
-- Export AdonisFX setup into a JSON file.
+- Gather the Adonis nodes setup from the scene.
+- Clear the scene by removing all Adonis nodes and dependent nodes.
+- Build the Adonis setup in the scene from a dictionary.
+- Import Adonis setup from a JSON file.
+- Export Adonis setup into a JSON file.
 
 In the following sections, we provide a brief overview of how to use the utilities provided in this Python module.
 
 ## Gather Data
 
-To gather all AdonisFX nodes from the scene and store their setup into a dictionary, run this command in Python:
+To gather all Adonis nodes from the scene and store their setup into a dictionary, run this command in Python:
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.scripts.houdini import adnio
 data = adnio.gather_from_scene(enabled_features, context)
 </code></pre>
 
-The argument `enabled_features` is optional and it is a dictionary where keys are feature names (i.e. AdonisFX solver nodes and other util nodes) and values are flags to determine if a feature has to be gathered or bypassed. If this is not provided, all features will be gathered.
+The argument `enabled_features` is optional and it is a dictionary where keys are feature names (i.e. Adonis solver nodes and other util nodes) and values are flags to determine if a feature has to be gathered or bypassed. If this is not provided, all features will be gathered.
 
-The second argument `context` is optional and it is the path to the geometry node where the AdonisFX rig should be gathered from (i.e. */obj/geo1*). If the argument is not provided, the rig will be gathered from the first found active geometry node in */obj*.
+The second argument `context` is optional and it is the path to the geometry node where the Adonis rig should be gathered from (i.e. */obj/geo1*). If the argument is not provided, the rig will be gathered from the first found active geometry node in */obj*.
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.utils.constants import IOFeaturesData
 enabled_features = {
@@ -41,35 +41,35 @@ context = "/obj/geo1"</code></pre>
 
 ## Clear All
 
-To clear all AdonisFX related nodes from the scene, run the command below in Python. This is useful for when AdonisFX data has to be imported onto a clean version of the rig.
+To clear all Adonis related nodes from the scene, run the command below in Python. This is useful for when Adonis data has to be imported onto a clean version of the rig.
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.scripts.houdini import adnio
 adnio.clear_scene()
 </code></pre>
 
 > [!NOTE]
-> In addition to removing all AdonisFX nodes, the clear utility will also remove the dependent nodes created between the null nodes *ADN_IN_* and *ADN_OUT_*, including them.
+> In addition to removing all Adonis nodes, the clear utility will also remove the dependent nodes created between the null nodes *ADN_IN_* and *ADN_OUT_*, including them.
 
 ## Build
 
-To build an AdonisFX setup in Python, it is required to provide the setup information in dictionary format. This dictionary data can be the value returned by the function `gather_from_scene` or the result of loading a JSON file exported previously with the function `export_data`. The code to build the AdonisFX setup is:
+To build an Adonis setup in Python, it is required to provide the setup information in dictionary format. This dictionary data can be the value returned by the function `gather_from_scene` or the result of loading a JSON file exported previously with the function `export_data`. The code to build the Adonis setup is:
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.scripts.houdini import adnio
 adnio.build_from_data(data, enabled_features, context)
 </code></pre>
 
-The first argument `data` is required and it is the dictionary with the mapped data. The second argument `enabled_features` is optional and corresponds to a dictionary where keys are feature names and values are flags to determine if a feature has to be built or bypassed (same format used for gathering data). The third argument `context` is optional and corresponds to the path to the geometry node where the AdonisFX rig should be built. If it is not provided, the rig will be built into the first found active geometry node in */obj*.
+The first argument `data` is required and it is the dictionary with the mapped data. The second argument `enabled_features` is optional and corresponds to a dictionary where keys are feature names and values are flags to determine if a feature has to be built or bypassed (same format used for gathering data). The third argument `context` is optional and corresponds to the path to the geometry node where the Adonis rig should be built. If it is not provided, the rig will be built into the first found active geometry node in */obj*.
 
 ## Import
 
-To import an AdonisFX setup from a JSON file, run the command below:
+To import an Adonis setup from a JSON file, run the command below:
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.scripts.houdini import adnio
 file_path = "path/to/source/file.json"
 adnio.import_data(file_path, enabled_features)
 </code></pre>
 
-The first argument `file_path` is required and it is the full path to the JSON file containing a valid AdonisFX setup definition. The second argument `enabled_features` is optional and corresponds to a dictionary where keys are feature names and values are flags to determine if a feature has to be imported or bypassed (same format used for gathering data).
+The first argument `file_path` is required and it is the full path to the JSON file containing a valid Adonis setup definition. The second argument `enabled_features` is optional and corresponds to a dictionary where keys are feature names and values are flags to determine if a feature has to be imported or bypassed (same format used for gathering data).
 
 > [!NOTE]
 > The rig will be imported into the first found geometry node with the visibility flag on. For that reason it is advisable to have one single geometry node in the */obj* context or at least only one active.
@@ -78,7 +78,7 @@ Find more information about the use of the import feature in the [Import](../too
 
 ## Export
 
-To export the AdonisFX setup in the current scene into a file, run this command:
+To export the Adonis setup in the current scene into a file, run this command:
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.scripts.houdini import adnio
 file_path = "path/to/destination/file.json"
@@ -94,7 +94,7 @@ Find more information about the use of the export feature in the [Export](../too
 
 ## Limitations
 
-- The `adnio` scripts do not support subnetworks inside of the Geometry context. This means that all AdonisFX SOP nodes (and any other SOP nodes containing geometry required by the AdonisFX rig) must exist at the same level within the Geometry context (e.g., */obj/geo1*).
+- The `adnio` scripts do not support subnetworks inside of the Geometry context. This means that all Adonis SOP nodes (and any other SOP nodes containing geometry required by the Adonis rig) must exist at the same level within the Geometry context (e.g., */obj/geo1*).
 - Only one active geometry node (with the visibility/display flag enabled) in the */obj* context is allowed for the `adnio` scripts to work.
 - Nodes used to drive attachment to transform or slide on segment constraints (e.g. null, joint or rivet nodes) must live in the */obj* context.
 - KineFX joint transforms are not supported.

--- a/docs/houdini/scripts/turbo.md
+++ b/docs/houdini/scripts/turbo.md
@@ -1,6 +1,6 @@
 # AdnTurbo
 
-The AdnTurbo script is a Python script that automates the setup of an AdonisFX rig on a clean asset. It configures the following layers in sequence:
+The AdnTurbo script is a Python script that automates the setup of an Adonis rig on a clean asset. It configures the following layers in sequence:
 
 - **Muscle layer**
 - **Locators and Sensors**
@@ -24,7 +24,7 @@ def apply_turbo(
     glue=True,                       # bool: enable glue layer
     locators=True,                   # bool: enable creation of locators and sensors
     space_scale=1.0,                 # float: simulation scale factor
-    force=False,                     # bool: remove existing AdonisFX nodes
+    force=False,                     # bool: remove existing Adonis nodes
     muscle_piece_attrib_name="path", # str: name of the primitive attribute used to separate the muscles
     report_data=None                 # dict: collects errors and warnings
 )
@@ -39,7 +39,7 @@ To configure at least the muscle layer, the following inputs are required:
 - **mummies**: one or more skeletal mesh to drive the muscle simulation.
 - **muscles**: one or more meshes representing muscles.
 
-When these two inputs are provided, the muscle layer will be completely configured including AdonisFX locators and sensors.
+When these two inputs are provided, the muscle layer will be completely configured including Adonis locators and sensors.
 
 To configure the downstream layers, the following inputs have to be provided:
 
@@ -68,7 +68,7 @@ In this section we provide a brief overview of the arguments of the `apply_turbo
 | **glue**                     | Optional | bool           | True   | If True, creates an AdnGlue node using all muscles merged as input. |
 | **locators**                 | Optional | bool           | True   | If True, creates sticky nodes, sensors and locators for each muscle. |
 | **space_scale**              | Optional | float          | 1.0    | Factor to scale simulation space. It will be set to the space scale attribute of all the solvers created. |
-| **force**                    | Optional | bool           | False  | If True, deletes all existing AdonisFX nodes before executing to create the new nodes from a clean scene. |
+| **force**                    | Optional | bool           | False  | If True, deletes all existing Adonis nodes before executing to create the new nodes from a clean scene. |
 | **muscle_piece_attrib_name** | Optional | string         | `path` | String defining the name of the primitive attribute that will be used to identify each muscle geometry. |
 | **report_data**              | Optional | dictionary     | None   | A dictionary (`{"errors": [], "warnings": []}`) to capture any issues during execution. |
 
@@ -131,7 +131,7 @@ for warn in report_data["warnings"]:
 
 > [!NOTE]
 > - Note that the whole AdnTurbo can be undone.
-> - If there are AdonisFX nodes in the scene and the `force` argument is set to `False` the AdnTurbo script will generate an error in `report_data` indicating to clear the scene or to run the script again with `force=True` to automatically delete all the AdonisFX nodes.
+> - If there are Adonis nodes in the scene and the `force` argument is set to `False` the AdnTurbo script will generate an error in `report_data` indicating to clear the scene or to run the script again with `force=True` to automatically delete all the Adonis nodes.
 > - Fascia and fat meshes must have the same topology for the AdnFat deformer to be created by AdnTurbo.
 > - AdnTurbo can also be executed with the **AdnTurbo Tool**. For more details, please refer to the [AdnTurbo Tool page](../tools/turbo_tool).
 
@@ -140,7 +140,7 @@ for warn in report_data["warnings"]:
 As a result of executing the script by providing the geometries for all the layers, the following nodes will be created:
 
 - An AdnMuscle for each muscle geometry with the mummy geometries as targets.
-- An AdonisFX locator and sensor for each AdnMuscle to drive the muscle activation.
+- An Adonis locator and sensor for each AdnMuscle to drive the muscle activation.
 - An AdnGlue node with all the muscles merged as input.
 - An AdnSkin node for the fascia geometry with the mummy and glue as targets.
 - An AdnRelax node applied on top of the fascia AdnSkin.

--- a/docs/houdini/simple_setup.md
+++ b/docs/houdini/simple_setup.md
@@ -1,6 +1,6 @@
 # A Simple Setup
 
-This page is dedicated to explain, step by step, a simple process of creating and setting the main AdonisFX solvers and deformers SOPs in Houdini. The scenarios presented here are intended to provide the minimum required configurations to obtain plausible results.
+This page is dedicated to explain, step by step, a simple process of creating and setting the main Adonis solvers and deformers SOPs in Houdini. The scenarios presented here are intended to provide the minimum required configurations to obtain plausible results.
 
 ## AdnMuscle
 
@@ -18,11 +18,11 @@ In this case the proposed example is to simulate a biceps in an animated full bo
 
 ### Create Deformer
 
-To create the AdnMuscle SOP, press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnMuscle SOP ![AdnMuscle](../images/adn_muscle.png){style="width:4%"} type. Then connect the muscle geometry to the input of the AdnMuscle node.
+To create the AdnMuscle SOP, press TAB and navigate to the submenu Adonis > Solvers to find the AdnMuscle SOP ![AdnMuscle](../images/adn_muscle.png){style="width:4%"} type. Then connect the muscle geometry to the input of the AdnMuscle node.
 
 <figure markdown>
   ![AdnMuscle SOP creation scenario](images/simple_setup_muscle_01.png)
-  <figcaption><b>Figure 2</b>: AdnMuscle SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 2</b>: AdnMuscle SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 In order to add targets to the muscles, go to the *Targets* tab on the AdnMuscle node, press **+** under the *Targets* collapsible to add a new entry and provide the path to the SOP containing the target geometry. The geometries added as targets can be used to drive attachment to geometry and slide on geometry constraints.
@@ -42,7 +42,7 @@ Optionally, add Slide On Segment Constraints. This constraint works in a similar
 
 ### Paint Weights
 
-To tweak the point attributes of an AdnMuscle SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnMuscle SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnMuscle node.
+To tweak the point attributes of an AdnMuscle SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnMuscle SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnMuscle node.
 
 <figure style="width:75%" markdown>
   ![Deformable section muscle](images/simple_setup_muscle_03.png)
@@ -71,11 +71,11 @@ Then, paint the muscle tendon weights, by selecting the *Tendon* attribute from 
   <figcaption><b>Figure 7</b>: Tendon weights for biceps.</figcaption>
 </figure>
 
-Once tendons are painted it is possible to groom the fibers making use of the AdnFiberGroom HDA. To create this node, press TAB, navigate to the submenu AdonisFX > Utils to find the AdnFiberGroom ![AdnFiberGroom button](../images/adn_fiber_groom.png){style="width:4%"} HDA type and connect it to the AdnMuscle after the `attribpaint` node.
+Once tendons are painted it is possible to groom the fibers making use of the AdnFiberGroom HDA. To create this node, press TAB, navigate to the submenu Adonis > Utils to find the AdnFiberGroom ![AdnFiberGroom button](../images/adn_fiber_groom.png){style="width:4%"} HDA type and connect it to the AdnMuscle after the `attribpaint` node.
 
 To visualize, change the fiber size or its color, go to the debug submenu in the SOP node, and customize the color and length of the drawn lines.
 
-To simplify the creation of the AdnFiberGroom HDA, AdonisFX provides *Make Groomable* utility in AdonisFX > Utils. Use this utility by providing the corresponding AdnMuscle SOP in the selection to create an AdnFiberGroom node that computes the initial fiber directions based on the previously painted `adnTendons` map. It also allows to further groom and refine the fibers if additional adjustments are needed. The AdnFiberGroom node will be automatically named and properly connected to the muscle SOP node.
+To simplify the creation of the AdnFiberGroom HDA, Adonis provides *Make Groomable* utility in Adonis > Utils. Use this utility by providing the corresponding AdnMuscle SOP in the selection to create an AdnFiberGroom node that computes the initial fiber directions based on the previously painted `adnTendons` map. It also allows to further groom and refine the fibers if additional adjustments are needed. The AdnFiberGroom node will be automatically named and properly connected to the muscle SOP node.
 
 <figure style="width:70%" markdown>
   ![Deformable section after using the Make Groomable utility](images/simple_setup_muscle_05.png)
@@ -103,9 +103,9 @@ Finally, paint Slide On Segment or Slide On Geometry Constraints (if added). It 
 
 To have the muscle changing and responding to external inputs (i.e. the flexion of the arm), AdnSensorRotation can be added to drive the activation of the muscle. 
 
-To do this, first create a rotation sensor to compute the elbow angle. Press TAB and navigate to the submenu AdonisFX > Sensors to find the AdnSensorRotation ![AdnSensorRotation button](../images/adn_angle_sensor.png){style="width:4%"} SOP type.
+To do this, first create a rotation sensor to compute the elbow angle. Press TAB and navigate to the submenu Adonis > Sensors to find the AdnSensorRotation ![AdnSensorRotation button](../images/adn_angle_sensor.png){style="width:4%"} SOP type.
 
-Then create a rotation locator to visualize the elbow angle. Press TAB and navigate to the submenu AdonisFX > Locators to find the AdnLocatorRotation ![AdnLocatorRotation button](../images/adn_angle_locator.png){style="width:4%"} SOP type and connect the sensor to the locator.
+Then create a rotation locator to visualize the elbow angle. Press TAB and navigate to the submenu Adonis > Locators to find the AdnLocatorRotation ![AdnLocatorRotation button](../images/adn_angle_locator.png){style="width:4%"} SOP type and connect the sensor to the locator.
 
 Once the sensor and locator are created, go to the *Input* tab of both nodes and provide the SOP paths to the transform nodes from which to extract the transformation information (e.g. shoulder, elbow and wrist joints). Alternatively, use the "Operator Chooser" in the locator and sensor UI to select the correct target nodes containing transform information. Generally these input nodes will be located on the */obj* level as a null, joint or rivet.
 
@@ -143,11 +143,11 @@ In this case a planar muscle will be simulated corresponding to a biceps, which 
 
 ### Create Deformer
 
-Similar to AdnMuscle, to create the AdnRibbonMuscle SOP, press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnRibbonMuscle ![AdnRibbonMuscle](../images/adn_ribbon_muscle.png){style="width:4%"} SOP type. Then connect the planar muscle geometry to the input of the AdnRibbonMuscle node.
+Similar to AdnMuscle, to create the AdnRibbonMuscle SOP, press TAB and navigate to the submenu Adonis > Solvers to find the AdnRibbonMuscle ![AdnRibbonMuscle](../images/adn_ribbon_muscle.png){style="width:4%"} SOP type. Then connect the planar muscle geometry to the input of the AdnRibbonMuscle node.
 
 <figure markdown>
   ![AdnRibbonMuscle SOP creation scenario](images/simple_setup_ribbon_muscle_01.png)
-  <figcaption><b>Figure 15</b>: AdnRibbonMuscle SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 15</b>: AdnRibbonMuscle SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 In order to add targets to the muscles, go to the *Targets* tab on the AdnRibbonMuscle node, press **+** under the *Targets* collapsible to add a new entry and provide the path to the SOP containing the target geometry. The geometries added as targets can be used to drive attachment to geometry and slide on geometry constraints.
@@ -167,7 +167,7 @@ Optionally, add Slide On Segment Constraints. This constraint works in a similar
 
 ### Paint Weights
 
-To tweak the point attributes of an AdnRibbonMuscle SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnRibbonMuscle SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnRibbonMuscle node.
+To tweak the point attributes of an AdnRibbonMuscle SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnRibbonMuscle SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnRibbonMuscle node.
 
 <figure style="width:75%" markdown>
   ![Deformable section ribbon muscle](images/simple_setup_ribbon_muscle_03.png)
@@ -198,9 +198,9 @@ In case the fiber or its color has to be manipulated, go to the debug submenu in
   <figcaption><b>Figure 20</b>: Tendon weights for biceps.</figcaption>
 </figure>
 
-Once tendons are painted it is possible to groom the fibers making use of the AdnFiberGroom HDA. To create this node, press TAB, navigate to the submenu AdonisFX > Utils to find the AdnFiberGroom ![AdnFiberGroom button](../images/adn_fiber_groom.png){style="width:4%"} HDA type and connect it to the AdnRibbonMuscle after the `attribpaint` node.
+Once tendons are painted it is possible to groom the fibers making use of the AdnFiberGroom HDA. To create this node, press TAB, navigate to the submenu Adonis > Utils to find the AdnFiberGroom ![AdnFiberGroom button](../images/adn_fiber_groom.png){style="width:4%"} HDA type and connect it to the AdnRibbonMuscle after the `attribpaint` node.
 
-To simplify the creation of the AdnFiberGroom HDA, AdonisFX provides *Make Groomable* utility in AdonisFX > Utils. Use this utility by providing the corresponding AdnRibbonMuscle SOP in the selection to create an AdnFiberGroom node that computes the initial fiber directions based on the previously painted `adnTendons` map. It also allows to further groom and refine the fibers if additional adjustments are needed. The AdnFiberGroom node will be automatically named and properly connected to the muscle SOP node.
+To simplify the creation of the AdnFiberGroom HDA, Adonis provides *Make Groomable* utility in Adonis > Utils. Use this utility by providing the corresponding AdnRibbonMuscle SOP in the selection to create an AdnFiberGroom node that computes the initial fiber directions based on the previously painted `adnTendons` map. It also allows to further groom and refine the fibers if additional adjustments are needed. The AdnFiberGroom node will be automatically named and properly connected to the muscle SOP node.
 
 <figure style="width:70%" markdown>
   ![Deformable section ribbon muscle after using the Make Groomable util](images/simple_setup_ribbon_muscle_05.png)
@@ -246,11 +246,11 @@ The AdnGlue node will take all the simulated muscles merged as a single input.
 
 > [!NOTE]
 > - AdnGlue requires the input geometry to contain a primitive attribute to be able to identify each muscle.
-> - If the AdnGlue input does not contain a primitive attribute, click on AdonisFX > Utils > Create Muscle PieceID by having the AdnGlue input selected. This utility will create a `connectivity` node in charge of computing the primitive attribute that will identify each muscle piece.
+> - If the AdnGlue input does not contain a primitive attribute, click on Adonis > Utils > Create Muscle PieceID by having the AdnGlue input selected. This utility will create a `connectivity` node in charge of computing the primitive attribute that will identify each muscle piece.
 
 ### Create Node
 
-To create the AdnGlue node, press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnGlue ![AdnGlue](../images/adn_glue.png){style="width:4%"} SOP type. Then connect the merged muscles to the AdnGlue input and select the *Piece Attribute* to allow the SOP to identify each muscle piece.
+To create the AdnGlue node, press TAB and navigate to the submenu Adonis > Solvers to find the AdnGlue ![AdnGlue](../images/adn_glue.png){style="width:4%"} SOP type. Then connect the merged muscles to the AdnGlue input and select the *Piece Attribute* to allow the SOP to identify each muscle piece.
 
 Input muscles can be added or removed from the existing AdnGlue by connecting or disconnecting them from the merge node. After that, make sure to recook the AdnGlue at preroll start time for this change to take effect.
 
@@ -266,7 +266,7 @@ The *Max Glue Distance* attribute is set to 0.0 by default. Therefore, for the g
 
 ### Paint Weights
 
-To tweak the point attributes of an AdnGlue SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnGlue SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnGlue node.
+To tweak the point attributes of an AdnGlue SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnGlue SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnGlue node.
 
 <figure markdown>
   ![Deformable section glue](images/simple_setup_glue_00.png)
@@ -316,18 +316,18 @@ To create a basic scenario using the AdnFat SOP, start with a scene with the fol
 
 ### Create Node
 
-To create the AdnFat SOP, press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnFat ![AdnFat](../images/adn_fat.png){style="width:4%"} SOP type. Then connect the fat mesh to the first input and the base mesh (e.g. the simulated fascia) to the second input.
+To create the AdnFat SOP, press TAB and navigate to the submenu Adonis > Solvers to find the AdnFat ![AdnFat](../images/adn_fat.png){style="width:4%"} SOP type. Then connect the fat mesh to the first input and the base mesh (e.g. the simulated fascia) to the second input.
 
 <figure markdown>
   ![AdnFat SOP creation scenario](images/simple_setup_fat_01.png)
-  <figcaption><b>Figure 32</b>: AdnFat SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 32</b>: AdnFat SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 After basic configuration, to alter the dynamics of the fat layer (e.g. adding or reducing the jiggle) it is advisable to tweak the main attributes like: *Iterations*, *Substeps*, *Global Damping Multiplier* or the per-constraint stiffness values in the *Override Constraint Stiffness* section.
 
 ### Paint Weights
 
-To tweak the point attributes of an AdnFat SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnFat SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnFat node.
+To tweak the point attributes of an AdnFat SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnFat SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnFat node.
 
 <figure markdown>
   ![Deformable section fat](images/simple_setup_fat_02.png)
@@ -363,18 +363,18 @@ To create a basic scenario using the AdnSkin SOP, start with a scene with the fo
 
 ### Create Deformer
 
-To create the AdnSkin node, press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnSkin ![AdnSkin](../images/adn_skin.png){style="width:4%"} SOP type. Then connect the skin mesh to the AdnSkin input.
+To create the AdnSkin node, press TAB and navigate to the submenu Adonis > Solvers to find the AdnSkin ![AdnSkin](../images/adn_skin.png){style="width:4%"} SOP type. Then connect the skin mesh to the AdnSkin input.
 
 To add target mesh(es), go to the *Targets* tab on the AdnSkin node, press **+** to add a new target entry and set the path to the SOP node containing the target geometry to the *Target World Mesh* parameter.
 
 <figure markdown>
   ![AdnSkin SOP creation scenario](images/simple_setup_skin_01.png)
-  <figcaption><b>Figure 36</b>: AdnSkin SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 36</b>: AdnSkin SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 ### Paint Weights
 
-To tweak the point attributes of an AdnSkin SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSkin SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSkin node.
+To tweak the point attributes of an AdnSkin SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSkin SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSkin node.
 
 <figure markdown>
   ![Deformable section skin](images/simple_setup_skin_02.png)
@@ -419,7 +419,7 @@ To create a basic scenario using the AdnRelax SOP, start with a scene with a mes
 To create the AdnRelax SOP:
 
 1. Go to the geometry context of the rig containing the geometry to apply the SOP to.
-2. Press TAB and navigate to the submenu AdonisFX > Deformers to find the AdnRelax ![Relax button](../images/adn_relax.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Deformers to find the AdnRelax ![Relax button](../images/adn_relax.png){style="width:4%"} SOP type.
 3. Create it and connect the geometry to the input.
 4. Increase the number of iterations to see the effect of the relaxation algorithm.
 
@@ -432,7 +432,7 @@ To create the AdnRelax SOP:
 
 The AdnRelax paintable maps default to 1.0 if the point attributes are not found in the input source. They act as multipliers for the main relax parameters (i.e., *Smooth*, *Relax*, *Push In Ratio*, and *Push Out Ratio*). Therefore, the relaxation algorithm will be applied uniformly over the entire mesh unless the maps are adjusted.
 
-To tweak the point attributes of an AdnRelax SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnRelax SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnRelax node.
+To tweak the point attributes of an AdnRelax SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnRelax SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnRelax node.
 
 <figure markdown>
   ![relax network 2](images/simple_setup_relax_02.png)
@@ -472,11 +472,11 @@ A good example of a use case for the AdnPush SOP is to generate the internal fas
 
 ### Create Node
 
-To create the AdnPush SOP, press TAB and navigate to the submenu AdonisFX > Deformers to find the AdnPush ![AdnPush](../images/adn_push.png){style="width:4%"} SOP type and connect the copy of the skin mesh at rest to the AdnPush input. Then, set a negative value to the *Push Length* parameter to apply the push effect inwards (e.g. -2.0).
+To create the AdnPush SOP, press TAB and navigate to the submenu Adonis > Deformers to find the AdnPush ![AdnPush](../images/adn_push.png){style="width:4%"} SOP type and connect the copy of the skin mesh at rest to the AdnPush input. Then, set a negative value to the *Push Length* parameter to apply the push effect inwards (e.g. -2.0).
 
 <figure style="width:75%;" markdown>
   ![push SOP creation scenario](images/simple_setup_push_01.png)
-  <figcaption><b>Figure 46</b>: AdnPush SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 46</b>: AdnPush SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 <figure markdown>
@@ -488,7 +488,7 @@ Keeping the muscle layer visible is helpful to drive the configuration of the Ad
 
 ### Paint Weights
 
-To tweak the point attributes of an AdnPush SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnPush SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnPush node.
+To tweak the point attributes of an AdnPush SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnPush SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnPush node.
 
 <figure style="width:75%;" markdown>
   ![Deformable section push](images/simple_setup_push_03.png)
@@ -524,16 +524,16 @@ The AdnSkinMerge SOP will be applied to the final mesh which will be the result 
 
 ### Create Node
 
-To create the AdnSkinMerge node, press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnSkinMerge ![AdnSkinMerge](../images/adn_skin_merge.png){style="width:4%"} SOP type. Then connect the final mesh to the AdnSkinMerge input and go to the *Targets* tab to provide the *anim* and *sim* meshes. Make sure the initialization time corresponds to the start time where all the geometries are in rest pose.
+To create the AdnSkinMerge node, press TAB and navigate to the submenu Adonis > Solvers to find the AdnSkinMerge ![AdnSkinMerge](../images/adn_skin_merge.png){style="width:4%"} SOP type. Then connect the final mesh to the AdnSkinMerge input and go to the *Targets* tab to provide the *anim* and *sim* meshes. Make sure the initialization time corresponds to the start time where all the geometries are in rest pose.
 
 <figure markdown>
   ![AdnSkinMerge creation scenario](images/simple_setup_skin_merge_01.png)
-  <figcaption><b>Figure 52</b>: AdnSkinMerge SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 52</b>: AdnSkinMerge SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 ### Paint Weights
 
-To tweak the point attributes of an AdnSkinMerge SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSkinMerge SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSkinMerge node.
+To tweak the point attributes of an AdnSkinMerge SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSkinMerge SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSkinMerge node.
 
 <figure style="width: 70%;" markdown>
   ![Deformable section skin merge](images/simple_setup_skin_merge_02.png)
@@ -575,16 +575,16 @@ All these meshes must have the same number of vertices and correspond to the sam
 
 ### Create Node
 
-To create the AdnSimshape node, press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnSimshape ![AdnSimshape](../images/adn_simshape.png){style="width:4%"} SOP type. Then connect the animated mesh to the first input, the rest mesh to the third input and the deformation mesh to the fourth input.
+To create the AdnSimshape node, press TAB and navigate to the submenu Adonis > Solvers to find the AdnSimshape ![AdnSimshape](../images/adn_simshape.png){style="width:4%"} SOP type. Then connect the animated mesh to the first input, the rest mesh to the third input and the deformation mesh to the fourth input.
 
 <figure markdown>
   ![AdnSimshape creation scenario](images/simple_setup_simshape_01.png)
-  <figcaption><b>Figure 57</b>: AdnSimshape SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 57</b>: AdnSimshape SOP creation scenario. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 ### Paint Weights
 
-To tweak the point attributes of an AdnSimshape SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSimshape SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSimshape node.
+To tweak the point attributes of an AdnSimshape SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSimshape SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSimshape node.
 
 The most important paintable map is the `adnAttractForce` as this is the value that dictates how much of each simulated vertex should follow the animation. This value is flooded by default to 1.0, meaning that by default the simulated mesh will follow the animation completely, without displaying dynamics.
 
@@ -605,12 +605,12 @@ After painting similar weights to the ones displayed and pressing playback to ch
 
 To further have a realistic depiction of facial dynamics, facial muscle activations can be simulated. The AdnSimshape SOP has two methods of handling muscle activations:
 
- - AdonisFX Muscle Patches file.
+ - Adonis Muscle Patches file.
  - Edge Evaluator Node.
 
 Refer to this [section](solvers/simshape#muscle-activations) to see how to use Muscle Patches files. However, in this example, it is taken advantage of the AdnEdgeEvaluator SOP. The process is the following:
 
-- Press TAB and navigate to the submenu AdonisFX > Utils to find the AdnEdgeEvaluator ![Edge Evaluator button](../images/adn_edge_evaluator.png){style="width:4%"} SOP type.
+- Press TAB and navigate to the submenu Adonis > Utils to find the AdnEdgeEvaluator ![Edge Evaluator button](../images/adn_edge_evaluator.png){style="width:4%"} SOP type.
 - Connect the deformation mesh to the first input and the rest mesh to the second input.
 - Cook the AdnEdgeEvaluator node and the `adnCompression` point attribute will be written into the geostream.
 - Transfer the `adnCompression` point attribute to the geostream of the first input of AdnSimshape with the name `adnActivation`.

--- a/docs/houdini/solvers/fat.md
+++ b/docs/houdini/solvers/fat.md
@@ -20,7 +20,7 @@ An AdnFat setup requires the following inputs:
 The process to create an AdnFat is:
 
 1. Go to the geometry context of the rig containing the base and fat meshes.
-2. Press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnFat ![Fat button](../../images/adn_fat.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Solvers to find the AdnFat ![Fat button](../../images/adn_fat.png){style="width:4%"} SOP type.
 3. Create it and connect the fat geometry to the first input and the base geometry to the second input.
 4. The AdnFat is now ready to simulate using the default settings. Refer to the next section to customize their configuration.
 
@@ -45,7 +45,7 @@ The process to create an AdnFat is:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -120,7 +120,7 @@ The process to create an AdnFat is:
 > - All maps parameters are disabled in the Maps tab because the attribute names are fixed to drive specific functionalities of the solver.
 > - Fixed point attribute names also ensure compatibility with the API.
 > - To copy the map names of the disabled attributes for painting (using an attribute paint node) right click on the disabled map attribute parameter, press "Copy Parameter", select the attribute paint node and on the attribute name entry right click and press "Paste Values". This allows to easily copy the attribute name for painting.
-> - The *Make Paintable* utility provided in the AdonisFX menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnFat SOP.
+> - The *Make Paintable* utility provided in the Adonis menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnFat SOP.
 > - If a point attribute on the geostream does not match the naming convention exposed in the node, use an "Attribute Rename" node to rename the attribute to match the expected naming convention.
 
 ### Debug Attributes
@@ -171,11 +171,11 @@ In order to provide more artistic control, some key parameters of the AdnFat sol
 
 <figure style="width: 75%;" markdown>
   ![AdnFat example of network with attribpaint](../images/fat_net_example.png)
-  <figcaption><b>Figure 6</b>: Example of AdnFat network. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 6</b>: Example of AdnFat network. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 > [!NOTE]
-> To tweak the point attributes of an AdnFat SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnFat SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnFat node.
+> To tweak the point attributes of an AdnFat SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnFat SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnFat node.
 
 
 ## Debugger
@@ -210,6 +210,6 @@ To enable the debugger the *Debug* checkbox must be marked. To select the specif
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/solvers/glue.md
+++ b/docs/houdini/solvers/glue.md
@@ -16,7 +16,7 @@ To create an AdnGlue node within a Houdini scene, the following inputs must be p
   - **Input Geometry** (IG): Single geometry source containing all the geometries merged together. The geometry must include a per-primitive attribute to allow the solver to extract a list of separated geometries to be glued (e.g., `path`, `muscle_id`, `name`, etc).
 
 > [!NOTE]
-> - In the context of an AdonisFX rig, the merged geometries would generally be the output of the individually simulated muscles (via AdnMuscle or AdnRibbonMuscle SOPs). It is important to maintaining the piece attribute intact after merging them together to distinguish each separate muscle entity.
+> - In the context of an Adonis rig, the merged geometries would generally be the output of the individually simulated muscles (via AdnMuscle or AdnRibbonMuscle SOPs). It is important to maintaining the piece attribute intact after merging them together to distinguish each separate muscle entity.
 > - The order in which the geometries are merged can affect the output of the simulation result.
 > - Depending on the ordering of the point id's in the input (non-consecutive) the point id ordering on the output may not match.
 
@@ -24,7 +24,7 @@ To create an AdnGlue node within a Houdini scene, the following inputs must be p
 The process to create an AdnGlue node is:
 
 1. Select all the geometry nodes to glue and merge them together via `merge` SOP. Alternatively nodes like an `object_merge` node or similar can be used to combine the geometries.
-2. Press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnGlue ![Glue button](../../images/adn_glue.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Solvers to find the AdnGlue ![Glue button](../../images/adn_glue.png){style="width:4%"} SOP type.
 3. Create it and connect the merged geometry to the input.
 4. The solver is ready to simulate with default settings. Check the next section to customize their configuration.
 
@@ -55,7 +55,7 @@ The process to create an AdnGlue node is:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -153,7 +153,7 @@ The process to create an AdnGlue node is:
 > - All maps parameters are disabled in the Maps tab because the attribute names are fixed to drive specific functionalities of the solver.
 > - Fixed point attribute names also ensure compatibility with the API.
 > - To copy the map names of the disabled attributes for painting (using an attribute paint node) right click on the disabled map attribute parameter, press "Copy Parameter", select the attribute paint node and on the attribute name entry right click and press "Paste Values". This allows to easily copy the attribute name for painting.
-> - The *Make Paintable* utility provided in the AdonisFX menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnGlue SOP.
+> - The *Make Paintable* utility provided in the Adonis menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnGlue SOP.
 > - If a point attribute on the geostream does not match the naming convention exposed in the node, use an "Attribute Rename" node to rename the attribute to match the expected naming convention.
 
 ### Debug Attributes
@@ -216,11 +216,11 @@ In order to provide more artistic control, some key parameters of the AdnGlue so
 
 <figure style="width: 75%;" markdown>
   ![AdnGlue example of network with attribpaint](../images/glue_net_example.png) 
-  <figcaption><b>Figure 7</b>: Example of AdnGlue network. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 7</b>: Example of AdnGlue network. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 > [!NOTE]
-> To tweak the point attributes of an AdnGlue SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnGlue SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnGlue node.
+> To tweak the point attributes of an AdnGlue SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnGlue SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnGlue node.
 
 ## Debugger
 
@@ -266,6 +266,6 @@ Once the AdnGlue SOP is created, it is possible to add new inputs and remove cur
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/solvers/muscle.md
+++ b/docs/houdini/solvers/muscle.md
@@ -16,7 +16,7 @@ An AdnMuscle setup requires the following inputs:
 To create an AdnMuscle, follow these steps:
 
 1. Go to the geometry context of the rig containing the muscle geometries and ensure that the muscle is a single geometry piece.
-2. Press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnMuscle ![Muscle button](../../images/adn_muscle.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Solvers to find the AdnMuscle ![Muscle button](../../images/adn_muscle.png){style="width:4%"} SOP type.
 3. Create it and connect the geometry to the input.
 4. Go to the **Targets** tab in the AdnMuscle parameters, add a new entry to *Targets* to add a geometry target (e.g., the mummy).
 5. Provide the object path of the target geometry in *Target World Mesh*.
@@ -48,7 +48,7 @@ To create an AdnMuscle, follow these steps:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -176,7 +176,7 @@ To create an AdnMuscle, follow these steps:
 > - All maps parameters are disabled in the Maps tab because the attribute names are fixed to drive specific functionalities of the solver.
 > - Fixed point attribute names also ensure compatibility with the API.
 > - To copy the map names of the disabled attributes for painting (using an attribute paint node) right click on the disabled map attribute parameter, press "Copy Parameter", select the attribute paint node and on the attribute name entry right click and press "Paste Values". This allows to easily copy the attribute name for painting.
-> - The *Make Paintable* utility provided in the AdonisFX menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnMuscle SOP.
+> - The *Make Paintable* utility provided in the Adonis menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnMuscle SOP.
 > - If a point attribute on the geostream does not match the naming convention exposed in the node, use an "Attribute Rename" node to rename the attribute to match the expected naming convention.
 
 ### Debug Attributes
@@ -262,11 +262,11 @@ In order to provide more artistic control, some key parameters of the muscle sol
 
 <figure style="width: 75%;" markdown>
   ![AdnMuscle example of network with attribpaint and AdnFiberGroom HDA](../images/muscle_net_example.png) 
-  <figcaption><b>Figure 10</b>: Example of AdnMuscle network. The attribpaint node has to be placed prior to the AdnFiberGroom. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 10</b>: Example of AdnMuscle network. The attribpaint node has to be placed prior to the AdnFiberGroom. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 > [!NOTE]
-> To tweak the point attributes of an AdnMuscle SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnMuscle SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnMuscle node.
+> To tweak the point attributes of an AdnMuscle SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnMuscle SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnMuscle node.
 
 ## Debugger
 
@@ -409,7 +409,7 @@ The operators available are:
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
 

--- a/docs/houdini/solvers/ribbon.md
+++ b/docs/houdini/solvers/ribbon.md
@@ -17,7 +17,7 @@ An AdnRibbonMuscle setup requires the following inputs:
 To create an AdnRibbonMuscle, follow these steps:
 
 1. Go to the geometry context of the rig containing the muscle geometries and ensure that the muscle is a single geometry piece.
-2. Press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnRibbonMuscle ![Muscle button](../../images/adn_ribbon_muscle.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Solvers to find the AdnRibbonMuscle ![Muscle button](../../images/adn_ribbon_muscle.png){style="width:4%"} SOP type.
 3. Create it and connect the geometry to the input.
 4. Go to the **Targets** tab in the AdnRibbonMuscle parameters, add a new entry to *Targets* to add a geometry target (e.g., the mummy).
 5. Provide the object path of the target geometry in *Target World Mesh*.
@@ -46,7 +46,7 @@ To create an AdnRibbonMuscle, follow these steps:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -173,7 +173,7 @@ To create an AdnRibbonMuscle, follow these steps:
 > - All maps parameters are disabled in the Maps tab because the attribute names are fixed to drive specific functionalities of the solver.
 > - Fixed point attribute names also ensure compatibility with the API.
 > - To copy the map names of the disabled attributes for painting (using an attribute paint node) right click on the disabled map attribute parameter, press "Copy Parameter", select the attribute paint node and on the attribute name entry right click and press "Paste Values". This allows to easily copy the attribute name for painting.
-> - The *Make Paintable* utility provided in the AdonisFX menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnRibbonMuscle SOP.
+> - The *Make Paintable* utility provided in the Adonis menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnRibbonMuscle SOP.
 > - If a point attribute on the geostream does not match the naming convention exposed in the node, use an "Attribute Rename" node to rename the attribute to match the expected naming convention.
 
 ## Debug Attributes
@@ -260,11 +260,11 @@ In order to provide more artistic control, some key parameters of the muscle sol
 
 <figure style="width: 75%;" markdown>
   ![AdnRibbonMuscle example of network with attribpaint and AdnFiberGroom HDA](../images/ribbon_net_example.png) 
-  <figcaption><b>Figure 10</b>: Example of AdnRibbonMuscle network. The attribpaint node has to be placed prior to the AdnFiberGroom. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 10</b>: Example of AdnRibbonMuscle network. The attribpaint node has to be placed prior to the AdnFiberGroom. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 > [!NOTE]
-> To tweak the point attributes of an AdnRibbonMuscle SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnRibbonMuscle SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnRibbonMuscle node.
+> To tweak the point attributes of an AdnRibbonMuscle SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnRibbonMuscle SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnRibbonMuscle node.
 
 ## Debugger
 
@@ -397,7 +397,7 @@ The operators available are:
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
 

--- a/docs/houdini/solvers/simshape.md
+++ b/docs/houdini/solvers/simshape.md
@@ -11,7 +11,7 @@ The AdnSimshape SOP is of great simplicity to set up and apply to a mesh within 
 To create an AdnSimshape SOP within a Houdini scene, the following inputs must be provided:
 
   - **Rest Mesh (R)**: Mesh with no deformation or animation (optional).
-  - **Deform Mesh (D)**: Mesh with deformation driven by the facial expressions (optional, only if muscle activations with AdonisFX Muscle Patches is required).
+  - **Deform Mesh (D)**: Mesh with deformation driven by the facial expressions (optional, only if muscle activations with Adonis Muscle Patches is required).
   - **Animated Mesh (A)**: Mesh with deformation driven by the facial expressions and animation result of the binding to the animation rig (optional).
   - **Simulation Mesh (S)**: Mesh to apply the SOP to. This mesh can be the animation mesh or a separate mesh with no deformation nor animation.
 
@@ -24,7 +24,7 @@ To create an AdnSimshape SOP within a Houdini scene, the following inputs must b
 To create an AdnSimshape, follow these steps:
 
   1. Go to the geometry context of the rig containing the input geometries.
-  2. Press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnSimshape ![Simshape button](../../images/adn_simshape.png){style="width:4%"} SOP type.
+  2. Press TAB and navigate to the submenu Adonis > Solvers to find the AdnSimshape ![Simshape button](../../images/adn_simshape.png){style="width:4%"} SOP type.
   3. Create it and connect **S** to the first input.
   4. Optionally, if **A**, **R** and **D** are available, connect them to the second, third and fourth inputs respectively.
   5. The AdnSimshape is now ready to simulate with default settings. Check the next section to customize their configuration.
@@ -43,8 +43,8 @@ To create an AdnSimshape, follow these steps:
 ### Muscles Activation Settings
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
-| **Activation Mode**          | Enumerator | No activation      | ✗ | Mode to drive the muscle activations. There are 3 different modes: <ul><li>Muscle Patches (Disabled by default): An AdonisFX Muscle Patches file (`.amp`) has to be provided to enable this option.</li><li>Plug Values (Disabled by default): The activation values will be read from the per-point `adnActivation` attribute stored in the first input geometry. </li><li>No Activation (Enabled by default): No activation is read.</li></ul> |
-| **Muscle Patches File**      | String     |                    | ✗ | Path to the AdonisFX Muscle Patches file (`.amp`). |
+| **Activation Mode**          | Enumerator | No activation      | ✗ | Mode to drive the muscle activations. There are 3 different modes: <ul><li>Muscle Patches (Disabled by default): An Adonis Muscle Patches file (`.amp`) has to be provided to enable this option.</li><li>Plug Values (Disabled by default): The activation values will be read from the per-point `adnActivation` attribute stored in the first input geometry. </li><li>No Activation (Enabled by default): No activation is read.</li></ul> |
+| **Muscle Patches File**      | String     |                    | ✗ | Path to the Adonis Muscle Patches file (`.amp`). |
 | **Activation Attribute**     | String     | `adnActivation`    | ✗ | Name of the per-point attribute to read the activation values from. The activation values will be read from this attribute when the *Activation Mode* is set to *Plug Values*. The expected range of the per-point values is \[0.0, 1.0\]. |
 | **Activation Smoothing**     | Integer    | 1                  | ✗ | Number of iterations for the activation smoothing algorithm. The greater the number, the smoother the activations per patch will be. Has a range of \[1, 20\]. The upper limit is soft, higher values can be used. |
 | **Bidirectional Activation** | Boolean    | False              | ✓ | Flag to enable muscle activations in the positive and negative directions of the muscle patches fibers. |
@@ -65,7 +65,7 @@ To create an AdnSimshape, follow these steps:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -163,7 +163,7 @@ To create an AdnSimshape, follow these steps:
 > - All maps parameters are disabled in the Maps tab because the attribute names are fixed to drive specific functionalities of the solver.
 > - Fixed point attribute names also ensure compatibility with the API.
 > - To copy the map names of the disabled attributes for painting (using an attribute paint node) right click on the disabled map attribute parameter, press "Copy Parameter", select the attribute paint node and on the attribute name entry right click and press "Paste Values". This allows to easily copy the attribute name for painting.
-> - The *Make Paintable* utility provided in the AdonisFX menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnSimshape SOP.
+> - The *Make Paintable* utility provided in the Adonis menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnSimshape SOP.
 > - If a point attribute on the geostream does not match the naming convention exposed in the node, use an "Attribute Rename" node to rename the attribute to match the expected naming convention.
 
 ### Debug Attributes
@@ -223,11 +223,11 @@ In order to provide more artistic control, some key parameters of the AdnSimshap
 
 <figure style="width: 75%;" markdown>
   ![AdnSimshape example of network](../images/simshape_net_example.png) 
-  <figcaption><b>Figure 7</b>: Example of AdnSimshape network. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 7</b>: Example of AdnSimshape network. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 > [!NOTE]
-> To tweak the point attributes of an AdnSimshape SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSimshape SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSimshape node.
+> To tweak the point attributes of an AdnSimshape SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSimshape SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSimshape node.
 
 ## Debugger
 
@@ -237,7 +237,7 @@ To better visualize deformer constraints and attributes in the Houdini viewport 
 To enable the debugger the *Debug* checkbox must be marked. To select the specific feature to visualize, choose it from the list provided in *Features*. The features that can be visualized with the debugger in the AdnSimshape deformer are:
 
  - **Distance Constraints**: For each pair of vertices forming a constraint a line will be drawn. If the *Triangulate Mesh* option is disabled the debugged lines will align with the edges of the mesh polygons. If the *Triangulate Mesh* option is enabled the debugged lines will align with the edges of the underlying triangulation of the mesh.
- - **Muscle Fibers**: For each vertex, a line will be drawn showing the direction of the muscle fibers. The debug lines will only be displayed in case muscle activations have been enabled with an AdonisFX Muscle Patches file.
+ - **Muscle Fibers**: For each vertex, a line will be drawn showing the direction of the muscle fibers. The debug lines will only be displayed in case muscle activations have been enabled with an Adonis Muscle Patches file.
  - **Shape Preservation**: For each vertex with a shape preservation weight greater than 0.0, a line will be drawn from each adjacent vertex to the opposite adjacent vertex.
  - **Slide Collision Constraints**: For each vertex, a line will be drawn from the mesh to the closest point of a collider. The debug lines will only be displayed in case collisions are enabled and colliders have been set up.
  - **Sliding Surface On Collider**: For each vertex, lines will outline the collider triangles within the reach of its *Max Sliding Distance*
@@ -275,8 +275,8 @@ AdnSimshape can emulate the behavior of facial muscles by computing the muscle a
 
 > [!NOTE = Activation Modes]
 > === Muscle Patches
-> The data in the AdonisFX Muscle Patches file in combination with the deformation status of the Deform Mesh are used to calculate the amount of activation at each vertex. The AMP file is the result of a Machine Learning process and can be generated following the steps presented in the next section. The requirements for this mode to work are:
->  - AdonisFX Muscle Patches file
+> The data in the Adonis Muscle Patches file in combination with the deformation status of the Deform Mesh are used to calculate the amount of activation at each vertex. The AMP file is the result of a Machine Learning process and can be generated following the steps presented in the next section. The requirements for this mode to work are:
+>  - Adonis Muscle Patches file
 >  - Deform mesh
 >
 >  === Plug Values (Point Attribute)
@@ -311,7 +311,7 @@ The AdnLearnMusclePatches SOP allows the user to generate the AMP file:
 
 
 1. Go to the geometry context of the rig containing the neutral and target meshes.
-2. Press TAB and navigate to the submenu AdonisFX > Utils to find the AdnLearnMusclePatches ![Learn Muscle Patches icon](../../images/adn_learn_muscle_patches.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Utils to find the AdnLearnMusclePatches ![Learn Muscle Patches icon](../../images/adn_learn_muscle_patches.png){style="width:4%"} SOP type.
 3. Create it and connect the neutral mesh to the first input.
 4. Connect the target meshes to the second input. These geometries are the set of facial expressions produced by blendshapes or a facial rig.
 5. Specify the *Targets Piece Attribute* to be able to split the target geometries into single pieces.
@@ -365,6 +365,6 @@ The use of rest collider is recommended when the pre-roll simulation is not comp
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.

--- a/docs/houdini/solvers/skin.md
+++ b/docs/houdini/solvers/skin.md
@@ -16,7 +16,7 @@ To create an AdnSkin the following inputs must be provided:
 The process to create the AdnSkin is:
 
 1. Go to the geometry context of the rig containing the geometry to simulate.
-2. Press TAB and navigate to the submenu AdonisFX > Solvers to find the AdnSkin ![Skin button](../../images/adn_skin.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Solvers to find the AdnSkin ![Skin button](../../images/adn_skin.png){style="width:4%"} SOP type.
 3. Create it and connect the geometry to the input.
 4. Go to the **Targets** tab in the AdnSkin parameters, add a new entry to *Targets* to add a geometry target (e.g., the glued muscles to simulate the fascia, the fat geometry to simulate the skin).
 5. Provide the object path of the target geometry in *Target World Mesh*.
@@ -43,7 +43,7 @@ The process to create the AdnSkin is:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Houdini), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -162,7 +162,7 @@ The process to create the AdnSkin is:
 > - All maps parameters are disabled in the Maps tab because the attribute names are fixed to drive specific functionalities of the solver.
 > - Fixed point attribute names also ensure compatibility with the API.
 > - To copy the map names of the disabled attributes for painting (using an attribute paint node) right click on the disabled map attribute parameter, press "Copy Parameter", select the attribute paint node and on the attribute name entry right click and press "Paste Values". This allows to easily copy the attribute name for painting.
-> - The *Make Paintable* utility provided in the AdonisFX menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnSkin SOP.
+> - The *Make Paintable* utility provided in the Adonis menu > Utils, can be used to create the attribpaint node and automatically populate the entries with the map names of the AdnSkin SOP.
 > - If a point attribute on the geostream does not match the naming convention exposed in the node, use an "Attribute Rename" node to rename the attribute to match the expected naming convention.
 
 ### Debug Attributes
@@ -224,7 +224,7 @@ In order to provide more artistic control, some key parameters of the AdnSkin so
 | **Stretching Resistance**                  | 1.0 | Force to correct the edge lengths if the current length is greater than the rest length. A higher value represents higher correction.<ul><li>*Tip*: To optimize the painting of the weight, flood it to 1.0 as a starting point and tweak some areas later on.</li><li>*Tip*: Smooth the borders by using the Smooth and Flood combination to make sure that there are no discontinuities in the weights map. This will help the simulation to not produce sharp differences in the dynamics of every vertex compared to its connected vertices.</li></ul> |
 
 > [!NOTE]
-> To tweak the point attributes of an AdnSkin SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSkin SOP and click on AdonisFX > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSkin node.
+> To tweak the point attributes of an AdnSkin SOP, an `attribpaint` is needed. To ease the creation and initial configuration of this node, select the AdnSkin SOP and click on Adonis > Utils > Make Paintable. This utility will create an `attribcreate` node to define the required point attributes and assign their default values followed by an `attribpaint` node to allow these attributes to be modified. Both nodes are automatically named and properly connected to the AdnSkin node.
 
 <figure markdown>
   ![Example of painted maps for AdnSkin](../images/skin_weights.png)
@@ -236,7 +236,7 @@ In order to provide more artistic control, some key parameters of the AdnSkin so
 
 <figure style="width: 75%;" markdown>
   ![AdnSkin example of network with attribpaint](../images/skin_net_example.png) 
-  <figcaption><b>Figure 8</b>: Example of AdnSkin network. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 8</b>: Example of AdnSkin network. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 ## Debugger
@@ -303,7 +303,7 @@ Once the AdnSkin SOP is created, it is possible to add and remove new targets to
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
 

--- a/docs/houdini/tools/exporter.md
+++ b/docs/houdini/tools/exporter.md
@@ -1,12 +1,12 @@
 # Export
 
-The AdonisFX Export is a tool designed to facilitate the export of a complete AdonisFX rig from a Houdini scene. This tool enables users to selectively export various components of an AdonisFX rig, ensuring a structured and efficient workflow for data transfer, backup, or reuse across different projects.
+The Adonis Export is a tool designed to facilitate the export of a complete Adonis rig from a Houdini scene. This tool enables users to selectively export various components of an Adonis rig, ensuring a structured and efficient workflow for data transfer, backup, or reuse across different projects.
 
 ## UI
 
 <figure style="width:50%;" markdown>
-  ![AdonisFX Export Tool](../images/exporter_ui.png)
-  <figcaption><b>Figure 1</b>: AdonisFX Export UI. </figcaption>
+  ![Adonis Export Tool](../images/exporter_ui.png)
+  <figcaption><b>Figure 1</b>: Adonis Export UI. </figcaption>
 </figure>
 
 The Export Tool offers an intuitive interface (see Figure 1), allowing users to configure export settings according to their specific requirements. Below is a breakdown of the available UI elements:​
@@ -26,7 +26,7 @@ The Export Tool offers an intuitive interface (see Figure 1), allowing users to 
     - Push: include AdnPush nodes in the exported data.
 
 - **Utils**: Allows exporting additional utility components from the setup. Options include:
-    - Sensors & Locators: include AdonisFX sensors and locators in the exported data, ensuring proper connections between components.
+    - Sensors & Locators: include Adonis sensors and locators in the exported data, ensuring proper connections between components.
     - Activation: include activation nodes and their existing connections to AdnMuscle nodes in the exported data.
     - Remap: include AdnRemap nodes in the exported data.
     - Edge Evaluator: include AdnEdgeEvaluator nodes in the exported data.
@@ -38,34 +38,34 @@ The Export Tool offers an intuitive interface (see Figure 1), allowing users to 
 
 ## Requirements
 
-An AdonisFX rig must meet some requirements to be exportable.
+An Adonis rig must meet some requirements to be exportable.
 
-- All geometries deformed by an AdonisFX SOP must be encapsulated within a deformable chain limited by two null nodes prefixed with "ADN_IN_" and "ADN_OUT_".
+- All geometries deformed by an Adonis SOP must be encapsulated within a deformable chain limited by two null nodes prefixed with "ADN_IN_" and "ADN_OUT_".
 
 <figure markdown>
-  ![AdonisFX Export Tool requirements part 1](../images/exporter_requirements_00.png)
-  <figcaption><b>Figure 2</b>: Exportable AdonisFX chain for the L_extensorDigitorum muscle and the simulated skin of an AdonisFX rig. All AdonisFX nodes affecting a geometry must be encapsulated by an ADN_IN null node and an ADN_OUT null node.</figcaption>
+  ![Adonis Export Tool requirements part 1](../images/exporter_requirements_00.png)
+  <figcaption><b>Figure 2</b>: Exportable Adonis chain for the L_extensorDigitorum muscle and the simulated skin of an Adonis rig. All Adonis nodes affecting a geometry must be encapsulated by an ADN_IN null node and an ADN_OUT null node.</figcaption>
 </figure>
 
 - The glue layer must receive all the input muscles merged together. The merged muscles must be the input to the ADN_IN null node of this layer.
 
 <figure markdown>
-  ![AdonisFX Export Tool requirements part 2](../images/exporter_requirements_01.png)
-  <figcaption><b>Figure 3</b>: Graph of the glue layer of an AdonisFX rig. All the input muscles are merged and connected to the ADN_IN null node.</figcaption>
+  ![Adonis Export Tool requirements part 2](../images/exporter_requirements_01.png)
+  <figcaption><b>Figure 3</b>: Graph of the glue layer of an Adonis rig. All the input muscles are merged and connected to the ADN_IN null node.</figcaption>
 </figure>
 
 - The muscle geometry must contain the piece attribute used by the glue solver (if any) to split the input geometry into individual muscle pieces.
 
 ## How To Use
 
-Open the scene of a fully configured AdonisFX rig (see Figure 2) and follow these steps:
+Open the scene of a fully configured Adonis rig (see Figure 2) and follow these steps:
 
 <figure markdown>
-  ![AdonisFX Export Tool exportable scene](../images/exporter_scene.png)
+  ![Adonis Export Tool exportable scene](../images/exporter_scene.png)
   <figcaption><b>Figure 4</b>: Fully configured rig of a biped character. The rig includes sensors, locators, activation nodes, muscles, glue, fascia, fat, skin, skin merge, and relax.</figcaption>
 </figure>
 
-1. Go to *AdonisFX menu > Export (beta)* to open the *Export* window.
+1. Go to *Adonis menu > Export (beta)* to open the *Export* window.
 
 2. Specify the file path where the exported data will be saved (e.g., `path/to/the/file.json`).
 
@@ -76,7 +76,7 @@ Open the scene of a fully configured AdonisFX rig (see Figure 2) and follow thes
 Depending on the complexity of the rig, the export process might take a few seconds to complete. Once finished, a JSON file containing the exported data will be created in the specified path.
 
 <figure markdown>
-  ![AdonisFX Export Tool exported file](../../images/exported_file.png)
+  ![Adonis Export Tool exported file](../../images/exported_file.png)
   <figcaption><b>Figure 5</b>: Example of the generated JSON file after exporting.</figcaption>
 </figure>
 
@@ -86,7 +86,7 @@ Depending on the complexity of the rig, the export process might take a few seco
 
 ## Limitations
 
-- The export tool does not support subnetworks inside of the Geometry context. This means that all AdonisFX SOP nodes (and any other SOP nodes containing geometry required by the AdonisFX rig) must exist at the same level within the Geometry context (e.g., */obj/geo1*).
+- The export tool does not support subnetworks inside of the Geometry context. This means that all Adonis SOP nodes (and any other SOP nodes containing geometry required by the Adonis rig) must exist at the same level within the Geometry context (e.g., */obj/geo1*).
 - Only one active geometry node (with the visibility/display flag enabled) in the */obj* context is allowed for the export tool to work.
 - Nodes used to drive attachment to transform or slide on segment constraints (e.g. null, joint or rivet nodes) must live in the */obj* context.
 - KineFX joint transforms are not supported.

--- a/docs/houdini/tools/importer.md
+++ b/docs/houdini/tools/importer.md
@@ -1,12 +1,12 @@
 # Import
 
-The AdonisFX Import is a tool designed to facilitate the import of a complete AdonisFX rig into a Houdini scene. This tool enables users to restore previously exported rigs by reading the data from a JSON file and rebuilding all selected components in the scene. The tool ensures a structured and efficient workflow for transferring, reusing, or backing up AdonisFX rigs.
+The Adonis Import is a tool designed to facilitate the import of a complete Adonis rig into a Houdini scene. This tool enables users to restore previously exported rigs by reading the data from a JSON file and rebuilding all selected components in the scene. The tool ensures a structured and efficient workflow for transferring, reusing, or backing up Adonis rigs.
 
 ## UI
 
 <figure style="width:50%;" markdown>
-  ![AdonisFX Import Tool](../images/importer_ui.png)
-  <figcaption><b>Figure 1</b>: AdonisFX Import UI.</figcaption>
+  ![Adonis Import Tool](../images/importer_ui.png)
+  <figcaption><b>Figure 1</b>: Adonis Import UI.</figcaption>
 </figure>
 
 The Import Tool offers an intuitive interface (see Figure 1), allowing users to configure import settings according to their specific requirements. Below is a breakdown of the available UI elements:
@@ -26,7 +26,7 @@ The Import Tool offers an intuitive interface (see Figure 1), allowing users to 
     - Push: imports AdnPush nodes and their settings.
 
 - **Utils**: Allows importing utility components from the JSON file. Options include:
-    - Sensors & Locators: imports AdonisFX sensors and locators, ensuring proper connections between components.
+    - Sensors & Locators: imports Adonis sensors and locators, ensuring proper connections between components.
     - Activation: imports activation nodes and their connections to AdnMuscle nodes.
     - Remap: imports AdnRemap nodes, including their settings and connections to other nodes.
     - Edge Evaluator: imports EdgeEvaluator nodes, including their settings and connections to other nodes.
@@ -38,38 +38,38 @@ The Import Tool offers an intuitive interface (see Figure 1), allowing users to 
 
 ## Requirements
 
-Before importing an AdonisFX rig, the target Houdini scene must meet the following requirements to ensure a successful reconstruction:
+Before importing an Adonis rig, the target Houdini scene must meet the following requirements to ensure a successful reconstruction:
 
 - Matching Geometry for *Solvers* and *Deformers*: Any geometry that had solvers or deformers applied in the original scene must also exist in the target scene. The geometries must have the same name and topology (i.e. same vertex count and vertex IDs) as in the exported scene to ensure that weight maps and settings are correctly restored.
 
-- Separated Muscle Pieces: The muscle geometries must be separated to allow the importer to create and configure the individual solvers. Also, each separated muscle geometry must preserve the piece attribute used for the splitting. The AdonisFX menu provides with a shortcut to extract and separate all the geometries from the selected node by piece attribute (i.e. by "path", "muscle_id" or "name", in this order) in *AdonisFX* > *Utils* > *Separate Geometries*.
+- Separated Muscle Pieces: The muscle geometries must be separated to allow the importer to create and configure the individual solvers. Also, each separated muscle geometry must preserve the piece attribute used for the splitting. The Adonis menu provides with a shortcut to extract and separate all the geometries from the selected node by piece attribute (i.e. by "path", "muscle_id" or "name", in this order) in *Adonis* > *Utils* > *Separate Geometries*.
 
 <figure markdown>
   ![Biped scene requirement](../images/importer_requirement.png)
   <figcaption><b>Figure 2</b>: Muscle pieces separated and renamed to match the muscle geometry names used in the original scene.</figcaption>
 </figure>
 
-- Matching Dependency Nodes for *Locators* and *Sensors*: Since AdonisFX locators and sensors rely on transform inputs, the target scene must contain nodes (i.e., rig joints) in the */obj* context with the same names as those used in the exported rig. This ensures that dependencies between nodes are restored properly.
+- Matching Dependency Nodes for *Locators* and *Sensors*: Since Adonis locators and sensors rely on transform inputs, the target scene must contain nodes (i.e., rig joints) in the */obj* context with the same names as those used in the exported rig. This ensures that dependencies between nodes are restored properly.
 
 
 ## How To Use
 
-To import an AdonisFX rig, ensure that you have a valid exported JSON file and follow these steps:
+To import an Adonis rig, ensure that you have a valid exported JSON file and follow these steps:
 
-1. Optionally, if the target scene contains any dirty or unwanted AdonisFX nodes, it may be advisable to remove all of them by using the *Clear* option provided in *AdonisFX menu > Utils > Clear*.
+1. Optionally, if the target scene contains any dirty or unwanted Adonis nodes, it may be advisable to remove all of them by using the *Clear* option provided in *Adonis menu > Utils > Clear*.
 
 <figure markdown>
   ![Biped scene before importing](../images/importer_scene_00.png)
   <figcaption><b>Figure 3</b>: Scene of a biped character after executing the Clear and ready to import.</figcaption>
 </figure>
 
-2. Go to *AdonisFX menu > Import (beta)* to open the *Import* window.
+2. Go to *Adonis menu > Import (beta)* to open the *Import* window.
 
 3. Specify the file path of the JSON file that contains the exported rig data.
 
 <figure markdown>
   ![Select JSON file](../../images/importer_file.png)
-  <figcaption><b>Figure 4</b>: File exported from an AdonisFX rig.</figcaption>
+  <figcaption><b>Figure 4</b>: File exported from an Adonis rig.</figcaption>
 </figure>
 
 4. Select the features to import from the *Solvers*, *Deformers* and *Utils* sections. To import the entire rig, enable all options.
@@ -80,7 +80,7 @@ Depending on the complexity of the rig, the import process might take a few seco
 
 <figure markdown>
   ![Select JSON file](../images/importer_scene_01.png)
-  <figcaption><b>Figure 5</b>: Scene after importing the rig from a JSON file. All AdonisFX nodes are created and configured. Some of them are visible in the node network: AdnMuscle for L_teresMinor_GEO, AdnSkin and AdnRelax for fascia_GEO and simSkin_GEO, AdnFat for fat_GEOShape and AdnSkinMerge for renderSkin_GEO.</figcaption>
+  <figcaption><b>Figure 5</b>: Scene after importing the rig from a JSON file. All Adonis nodes are created and configured. Some of them are visible in the node network: AdnMuscle for L_teresMinor_GEO, AdnSkin and AdnRelax for fascia_GEO and simSkin_GEO, AdnFat for fat_GEOShape and AdnSkinMerge for renderSkin_GEO.</figcaption>
 </figure>
 
 The previous steps corresponds to importing a rig that was exported from the same scene. However the same steps can be followed to transfer the exported rig to a different asset as long as the target scene fulfills the requirements listed in this [section](#requirements).
@@ -91,7 +91,7 @@ The previous steps corresponds to importing a rig that was exported from the sam
 
 ## Limitations
 
-- The import tool does not support subnetworks inside of the Geometry context. This means that all AdonisFX SOP nodes (and any other SOP nodes containing geometry required by the AdonisFX rig) must exist at the same level within the Geometry context (e.g., */obj/geo1*).
+- The import tool does not support subnetworks inside of the Geometry context. This means that all Adonis SOP nodes (and any other SOP nodes containing geometry required by the Adonis rig) must exist at the same level within the Geometry context (e.g., */obj/geo1*).
 - Only one active geometry node (with the visibility/display flag enabled) in the */obj* context is allowed for the import tool to work.
 - Nodes used to drive attachment to transform or slide on segment constraints (e.g. null, joint or rivet nodes) must live in the */obj* context.
 - KineFX joint transforms are not supported.

--- a/docs/houdini/tools/turbo_tool.md
+++ b/docs/houdini/tools/turbo_tool.md
@@ -1,6 +1,6 @@
 # AdnTurbo
 
-The **AdnTurbo Tool** is a feature designed to automate the creation of an AdonisFX rig from scratch on a clean asset within Houdini, from which fine-tuning and customization can proceed. It sequentially configures the following layers:
+The **AdnTurbo Tool** is a feature designed to automate the creation of an Adonis rig from scratch on a clean asset within Houdini, from which fine-tuning and customization can proceed. It sequentially configures the following layers:
 
 - **Muscle layer**
 - **Locators and Sensors**
@@ -64,11 +64,11 @@ Note that if any input is wrong or missing, the corresponding input text will tu
 > [!NOTE]
 > In this example only one mummy geometry is provided, however the *Mummies* entry also allows a list of mummy geometries (e.g. "/obj/geo1/L_mummy_shoulder_GEO", "/obj/geo1/L_mummy_forearmGEO", ...).
 
-3. If the scene contains AdonisFX nodes, a confirmation dialog will appear informing about it. Press *Yes* to automatically delete all AdonisFX nodes or *No* to cancel the execution.
+3. If the scene contains Adonis nodes, a confirmation dialog will appear informing about it. Press *Yes* to automatically delete all Adonis nodes or *No* to cancel the execution.
 
 <figure style="width:90%; margin-left:5%" markdown>
   ![Turbo Execution Completed](../images/turbo_tool_confirmation_dialog.png)
-  <figcaption><b>Figure 5</b>: Question dialog informing about AdonisFX nodes in the scene before executing.</figcaption>
+  <figcaption><b>Figure 5</b>: Question dialog informing about Adonis nodes in the scene before executing.</figcaption>
 </figure>
 
 4. If something goes wrong during the execution, an error dialog will be displayed informing about the problem to help with the troubleshooting. Note that the whole AdnTurbo can be undone.
@@ -88,7 +88,7 @@ Note that if any input is wrong or missing, the corresponding input text will tu
 As a result of executing the tool by providing the geometries for all the layers, the following nodes will be created:
 
 - An AdnMuscle for each muscle geometry with the mummy geometries as targets.
-- An AdonisFX locator and sensor for each AdnMuscle to drive the muscle activation.
+- An Adonis locator and sensor for each AdnMuscle to drive the muscle activation.
 - An AdnGlue node with all the muscles merged as input.
 - An AdnSkin node for the fascia geometry with the mummy and glue as targets.
 - An AdnRelax node applied on top of the fascia AdnSkin.

--- a/docs/houdini/ui_overview.md
+++ b/docs/houdini/ui_overview.md
@@ -1,72 +1,72 @@
 # UI Overview
 
-## AdonisFX TAB Menu
+## Adonis TAB Menu
 
-The AdonisFX nodes catalog can be inspected in the TAB Menu inside any geometry context under the submenu *AdonisFX*. It allows for quick access and creation of AdonisFX SOPs and HDAs. All of them are distributed in 5 submenus by type: Deformers, Locators, Sensors, Solvers and Utils.
+The Adonis nodes catalog can be inspected in the TAB Menu inside any geometry context under the submenu *Adonis*. It allows for quick access and creation of Adonis SOPs and HDAs. All of them are distributed in 5 submenus by type: Deformers, Locators, Sensors, Solvers and Utils.
 
 <figure style="width: 50%;" markdown>
-  ![AdonisFX TAB menu](images/ui_overview_tab_menu.png)
-  <figcaption><b>Figure 1</b>: AdonisFX TAB Menu.</figcaption>
+  ![Adonis TAB menu](images/ui_overview_tab_menu.png)
+  <figcaption><b>Figure 1</b>: Adonis TAB Menu.</figcaption>
 </figure>
 
 | Icon | Description | TAB Submenu |
 | :--- | :---------- | :---------- |
-| ![AdnRelax](../images/adn_relax.png) | Creates an AdnRelax SOP. A deformer used to smooth creases and correct over-compression or over-stretching on geometry. | AdonisFX > Deformers > *AdnRelax* |
-| ![AdnPush](../images/adn_push.png) | Creates an AdnPush SOP. A deformer that pushes the geometry surface along the normal direction. | AdonisFX > Deformers > *AdnPush* |
+| ![AdnRelax](../images/adn_relax.png) | Creates an AdnRelax SOP. A deformer used to smooth creases and correct over-compression or over-stretching on geometry. | Adonis > Deformers > *AdnRelax* |
+| ![AdnPush](../images/adn_push.png) | Creates an AdnPush SOP. A deformer that pushes the geometry surface along the normal direction. | Adonis > Deformers > *AdnPush* |
 |||
-| ![AdnLocatorPosition](../images/adn_point_locator.png) | Creates an AdnLocatorPosition SOP. Used to visualize the output values of an AdnSensorPosition SOP. | AdonisFX > Locators > *AdnLocatorPosition* |
-| ![AdnLocatorDistance](../images/adn_distance_locator.png) | Creates an AdnLocatorDistance SOP. Used to visualize the output values of an AdnSensorDistance SOP. | AdonisFX > Locators > *AdnLocatorDistance* |
-| ![AdnLocatorRotation](../images/adn_angle_locator.png) | Creates an AdnLocatorRotation SOP. Used to visualize the output values of an AdnSensorRotation SOP. | AdonisFX > Locators > *AdnLocatorRotation* |
+| ![AdnLocatorPosition](../images/adn_point_locator.png) | Creates an AdnLocatorPosition SOP. Used to visualize the output values of an AdnSensorPosition SOP. | Adonis > Locators > *AdnLocatorPosition* |
+| ![AdnLocatorDistance](../images/adn_distance_locator.png) | Creates an AdnLocatorDistance SOP. Used to visualize the output values of an AdnSensorDistance SOP. | Adonis > Locators > *AdnLocatorDistance* |
+| ![AdnLocatorRotation](../images/adn_angle_locator.png) | Creates an AdnLocatorRotation SOP. Used to visualize the output values of an AdnSensorRotation SOP. | Adonis > Locators > *AdnLocatorRotation* |
 |||
-| ![AdnSensorPosition](../images/adn_point_sensor.png) | Creates an AdnSensorPosition SOP. Designed to interpret changes in a transformation matrix’s position and output velocity and acceleration over time. | AdonisFX > Sensors > *AdnSensorPosition* |
-| ![AdnSensorDistance](../images/adn_distance_sensor.png) | Creates an AdnSensorDistance SOP. Designed to interpret positional changes between two transformation matrices and output the distance, velocity, and acceleration over time. | AdonisFX > Sensors > *AdnSensorDistance* |
-| ![AdnSensorRotation](../images/adn_angle_sensor.png) | Creates an AdnSensorRotation SOP. Designed to interpret positional changes between three transformation matrices and output the resulting angle, angular velocity, and angular acceleration over time. | AdonisFX > Sensors > *AdnSensorRotation* |
+| ![AdnSensorPosition](../images/adn_point_sensor.png) | Creates an AdnSensorPosition SOP. Designed to interpret changes in a transformation matrix’s position and output velocity and acceleration over time. | Adonis > Sensors > *AdnSensorPosition* |
+| ![AdnSensorDistance](../images/adn_distance_sensor.png) | Creates an AdnSensorDistance SOP. Designed to interpret positional changes between two transformation matrices and output the distance, velocity, and acceleration over time. | Adonis > Sensors > *AdnSensorDistance* |
+| ![AdnSensorRotation](../images/adn_angle_sensor.png) | Creates an AdnSensorRotation SOP. Designed to interpret positional changes between three transformation matrices and output the resulting angle, angular velocity, and angular acceleration over time. | Adonis > Sensors > *AdnSensorRotation* |
 |||
-| ![AdnFat](../images/adn_fat.png) | Creates an AdnFat SOP. Solver for fat tissue simulation. | AdonisFX > Solvers > *AdnFat* |
-| ![AdnGlue](../images/adn_glue.png) | Creates an AdnGlue SOP. Solver used to glue multiple muscles together, making them behave more compactly and react to each other. | AdonisFX > Solvers > *AdnGlue* |
-| ![AdnMuscle](../images/adn_muscle.png) | Creates an AdnMuscle SOP. Solver for volumetric muscle simulation. | AdonisFX > Solvers > *AdnMuscle* |
-| ![AdnRibbonMuscle](../images/adn_ribbon_muscle.png) | Creates an AdnRibbonMuscle SOP. Solver for planar muscle simulation. | AdonisFX > Solvers > *AdnRibbonMuscle* |
-| ![AdnSimshape](../images/adn_simshape.png) | Creates an AdnSimshape SOP. Solver for facial simulation. | AdonisFX > Solvers > *AdnSimshape* |
-| ![AdnSkin](../images/adn_skin.png) | Creates an AdnSkin SOP. Solver for fascia and skin simulation. | AdonisFX > Solvers > *AdnSkin* |
-| ![AdnSkinMerge](../images/adn_skin_merge.png) | Creates an AdnSkinMerge SOP. Node used to blend animation and simulation skin layers. | AdonisFX > Solvers > *AdnSkinMerge* |
+| ![AdnFat](../images/adn_fat.png) | Creates an AdnFat SOP. Solver for fat tissue simulation. | Adonis > Solvers > *AdnFat* |
+| ![AdnGlue](../images/adn_glue.png) | Creates an AdnGlue SOP. Solver used to glue multiple muscles together, making them behave more compactly and react to each other. | Adonis > Solvers > *AdnGlue* |
+| ![AdnMuscle](../images/adn_muscle.png) | Creates an AdnMuscle SOP. Solver for volumetric muscle simulation. | Adonis > Solvers > *AdnMuscle* |
+| ![AdnRibbonMuscle](../images/adn_ribbon_muscle.png) | Creates an AdnRibbonMuscle SOP. Solver for planar muscle simulation. | Adonis > Solvers > *AdnRibbonMuscle* |
+| ![AdnSimshape](../images/adn_simshape.png) | Creates an AdnSimshape SOP. Solver for facial simulation. | Adonis > Solvers > *AdnSimshape* |
+| ![AdnSkin](../images/adn_skin.png) | Creates an AdnSkin SOP. Solver for fascia and skin simulation. | Adonis > Solvers > *AdnSkin* |
+| ![AdnSkinMerge](../images/adn_skin_merge.png) | Creates an AdnSkinMerge SOP. Node used to blend animation and simulation skin layers. | Adonis > Solvers > *AdnSkinMerge* |
 |||
-| ![AdnActivation](../images/adn_activation.png) | Creates an AdnActivation SOP. Allows operations on a set of input values to compute a final value, which can be used, for example, to drive muscle activations. | AdonisFX > Utils > *AdnActivation* |
-| ![AdnEdgeEvaluator](../images/adn_edge_evaluator.png) | Creates an AdnEdgeEvaluator SOP. Used to compute a compression map on geometry based on edge deformation. | AdonisFX > Utils > *AdnEdgeEvaluator* |
-| ![AdnFiberDiffusion](../images/adn_fiber_diffusion.png) | Creates an AdnFiberDiffusion SOP. Utility SOP used by the *AdnFiberGroom* HDA to compute fiber vectors of a muscle driven by a tendons map. | AdonisFX > Utils > *AdnFiberDiffusion* |
-| ![AdnFiberGroom](../images/adn_fiber_groom.png) | Creates an AdnFiberGroom HDA. Allows combing of muscle fibers. | AdonisFX > Utils > *AdnFiberGroom* |
-| ![AdnFiberProjection](../images/adn_fiber_projection.png) | Creates an AdnFiberProjection SOP. Utility SOP used by the *AdnFiberGroom* HDA to process vectors resulting from fiber diffusion or combing and fully project them onto the muscle surface. | AdonisFX > Utils > *AdnFiberProjection* |
-| ![AdnLearnMusclePatches](../images/adn_learn_muscle_patches.png) | Creates an AdnLearnMusclePatches SOP. A machine learning–powered SOP used to generate an *AdonisFX Muscle Patches* file, which stores per-vertex fiber information that is required by *AdnSimshape* solver to compute muscle activations. | AdonisFX > Utils > *AdnLearnMusclePatches* |
-| ![AdnRemap](../images/adn_remap.png) | Creates an AdnRemap SOP. Utility SOP used to remap scalar values, typically to process sensor outputs for driving muscle activation or volume gain. | AdonisFX > Utils > *AdnRemap* |
+| ![AdnActivation](../images/adn_activation.png) | Creates an AdnActivation SOP. Allows operations on a set of input values to compute a final value, which can be used, for example, to drive muscle activations. | Adonis > Utils > *AdnActivation* |
+| ![AdnEdgeEvaluator](../images/adn_edge_evaluator.png) | Creates an AdnEdgeEvaluator SOP. Used to compute a compression map on geometry based on edge deformation. | Adonis > Utils > *AdnEdgeEvaluator* |
+| ![AdnFiberDiffusion](../images/adn_fiber_diffusion.png) | Creates an AdnFiberDiffusion SOP. Utility SOP used by the *AdnFiberGroom* HDA to compute fiber vectors of a muscle driven by a tendons map. | Adonis > Utils > *AdnFiberDiffusion* |
+| ![AdnFiberGroom](../images/adn_fiber_groom.png) | Creates an AdnFiberGroom HDA. Allows combing of muscle fibers. | Adonis > Utils > *AdnFiberGroom* |
+| ![AdnFiberProjection](../images/adn_fiber_projection.png) | Creates an AdnFiberProjection SOP. Utility SOP used by the *AdnFiberGroom* HDA to process vectors resulting from fiber diffusion or combing and fully project them onto the muscle surface. | Adonis > Utils > *AdnFiberProjection* |
+| ![AdnLearnMusclePatches](../images/adn_learn_muscle_patches.png) | Creates an AdnLearnMusclePatches SOP. A machine learning–powered SOP used to generate an *Adonis Muscle Patches* file, which stores per-vertex fiber information that is required by *AdnSimshape* solver to compute muscle activations. | Adonis > Utils > *AdnLearnMusclePatches* |
+| ![AdnRemap](../images/adn_remap.png) | Creates an AdnRemap SOP. Utility SOP used to remap scalar values, typically to process sensor outputs for driving muscle activation or volume gain. | Adonis > Utils > *AdnRemap* |
 |||
 
 
-## AdonisFX Menu
+## Adonis Menu
 
-The AdonisFX Menu provides access to some tools and utilities that are organized in four groups: Tools, I/O, License and Help.
+The Adonis Menu provides access to some tools and utilities that are organized in four groups: Tools, I/O, License and Help.
 
 <figure style="width: 30%;" markdown>
   ![AdnLocatorPosition within a scene](images/ui_overview_menu.png)
-  <figcaption><b>Figure 2</b>: AdonisFX Menu.</figcaption>
+  <figcaption><b>Figure 2</b>: Adonis Menu.</figcaption>
 </figure>
 
 ### Tools section
 
-- **Utils > Clear**. Removes all AdonisFX nodes from the scene.
+- **Utils > Clear**. Removes all Adonis nodes from the scene.
 
 - **Utils > Separate Geometry**. Separates the geometry of the selected SOP node into individual pieces based on a primitive attribute. The primitive attribute name must be `path`, `muscle_id` or `name`.
 
-- **Utils > Make Paintable**. Creates an `attribcreate` node to define the point attributes required by an AdonisFX SOP and assigns their default values followed by an `attribpaint` node to allow these attributes to be modified. This pair of nodes are created for each selected AdonisFX SOP. If no selection is provided, the nodes are created for all AdonisFX SOPs in the scene.
+- **Utils > Make Paintable**. Creates an `attribcreate` node to define the point attributes required by an Adonis SOP and assigns their default values followed by an `attribpaint` node to allow these attributes to be modified. This pair of nodes are created for each selected Adonis SOP. If no selection is provided, the nodes are created for all Adonis SOPs in the scene.
 
-- **Utils > Make Groomable**. Creates an AdnFiberGroom node for each AdonisFX muscle SOP (i.e. AdnMuscle and AdnRibbonMuscle) selected.  If no selection is provided, an AdnFiberGroom node will be created for each AdonisFX muscle SOP in the scene.
+- **Utils > Make Groomable**. Creates an AdnFiberGroom node for each Adonis muscle SOP (i.e. AdnMuscle and AdnRibbonMuscle) selected.  If no selection is provided, an AdnFiberGroom node will be created for each Adonis muscle SOP in the scene.
 
 - **Utils > Create Muscle PieceID**. Creates a `connectivity` node for each SOP in the selection in charge of computing the primitive attribute `path` that will identify each muscle piece.
 
-- **Turbo**. Opens the Turbo UI, which allows users to build an AdonisFX rig on a clean asset from scratch. The UI is divided into sections for each simulation layer that the AdnTurbo can configure. Users can toggle layers on or off to include or skip them in the execution and select the scene objects required to create and configure the solvers.
+- **Turbo**. Opens the Turbo UI, which allows users to build an Adonis rig on a clean asset from scratch. The UI is divided into sections for each simulation layer that the AdnTurbo can configure. Users can toggle layers on or off to include or skip them in the execution and select the scene objects required to create and configure the solvers.
 
 ### I/O section
 
-- **Import (beta)**. Opens the Import UI which allows to import an AdonisFX rig from a file in disk into the scene.
-- **Export (beta)**. Opens the Export UI which allows to export an AdonisFX rig from the scene into a file in disk.
+- **Import (beta)**. Opens the Import UI which allows to import an Adonis rig from a file in disk into the scene.
+- **Export (beta)**. Opens the Export UI which allows to export an Adonis rig from the scene into a file in disk.
 
 ### License section
 
@@ -74,6 +74,6 @@ The AdonisFX Menu provides access to some tools and utilities that are organized
 
 ### Help section
 
-- **Documentation**. Opens the AdonisFX technical documentation on a web browser.
-- **Tutorials**. Opens the AdonisFX tutorials on YouTube on a web browser.
-- **About**. Launches the AdonisFX About dialog with version information and credits.
+- **Documentation**. Opens the Adonis technical documentation on a web browser.
+- **Tutorials**. Opens the Adonis tutorials on YouTube on a web browser.
+- **About**. Launches the Adonis About dialog with version information and credits.

--- a/docs/houdini/utils/activation.md
+++ b/docs/houdini/utils/activation.md
@@ -7,7 +7,7 @@ The AdnActivation node allows operations on a set of input values for the comput
 To create this node, follow these steps:
 
 1. Go to the geometry context of the rig containing the rig setup to which the AdnActivation should be applied.
-2. Press TAB and navigate to the submenu AdonisFX > Utils to find the AdnActivation ![AdnActivation button](../../images/adn_activation.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Utils to find the AdnActivation ![AdnActivation button](../../images/adn_activation.png){style="width:4%"} SOP type.
 3. Go to the AdnActivation's *Inputs* and add a new input by clicking on the **+** button. A new multiparam entry will be created with three parameters: *Bypass Operator*, *Value* and *Operator*.
 4. Use a detail expression to drive the *Value*. For example, do this to use the output activation from a distance sensor: `detail("/obj/sim/my_dist_sensor", "adnActivationDistance", 0)`.
 5. The AdnActivation node is ready to compute and write the result into the `adnOutValue` output attribute.
@@ -92,7 +92,7 @@ The *Inputs* attribute is presented as an array of 3 attributes which can be fou
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
 

--- a/docs/houdini/utils/edge_evaluator.md
+++ b/docs/houdini/utils/edge_evaluator.md
@@ -15,7 +15,7 @@ This SOP requires the following inputs to be provided:
 To create this node, follow these steps:
 
 1. Go to the geometry context containing both the deform and the rest geometries.
-2. Press TAB and navigate to the submenu AdonisFX > Utils to find the AdnEdgeEvaluator ![Edge Evaluator button](../../images/adn_edge_evaluator.png){style="width:4%"} SOP type and create it.
+2. Press TAB and navigate to the submenu Adonis > Utils to find the AdnEdgeEvaluator ![Edge Evaluator button](../../images/adn_edge_evaluator.png){style="width:4%"} SOP type and create it.
 3. Connect the deform mesh to the first source and the rest mesh to the second source.
 4. Cook the node and the `adnCompression` point attribute is written into the geostream with the compression at each vertex.
 
@@ -60,7 +60,7 @@ The evaluator node can be used to drive the activations of an AdnSimshape SOP. T
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
 

--- a/docs/houdini/utils/fiber_diffusion.md
+++ b/docs/houdini/utils/fiber_diffusion.md
@@ -7,7 +7,7 @@ The AdnFiberDiffusion SOP is in charge of, given a defined tendon mask, generate
 To create this node, follow these steps:
 
 1. Go to the geometry context that has geometry with the painted `adnTendons` point attribute, generally on the tendon areas of a muscle. This can also be a combined geometry with a defined per-primitive piece attribute.
-2. Press TAB and navigate to the submenu AdonisFX > Utils to find the AdnFiberDiffusion ![AdnFiberDiffusion button](../../images/adn_fiber_diffusion.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Utils to find the AdnFiberDiffusion ![AdnFiberDiffusion button](../../images/adn_fiber_diffusion.png){style="width:4%"} SOP type.
 3. Connect the geometry to the first source.
 4. Cook the node and the `adnFibers` point attribute is written into the geostream with unprojected fiber directions used to drive the activation of an AdnMuscle or AdnRibbonMuscle node.
 

--- a/docs/houdini/utils/fiber_groom.md
+++ b/docs/houdini/utils/fiber_groom.md
@@ -7,23 +7,23 @@ The AdnFiberGroom node is a Houdini Digital Asset responsible for creating and e
 To create this node, follow these steps:
 
 1. Go to the geometry context that contains the muscle geometry for which fibers will be generated.
-2. Press TAB and navigate to the submenu AdonisFX > Utils to find the AdnFiberGroom ![AdnFiberGroom button](../../images/adn_fiber_groom.png){style="width:4%"} HDA type.
+2. Press TAB and navigate to the submenu Adonis > Utils to find the AdnFiberGroom ![AdnFiberGroom button](../../images/adn_fiber_groom.png){style="width:4%"} HDA type.
 3. Connect the muscle geometry to the AdnFiberGroom input.
 4. Cook the node and select it. Then click the Gizmos icon (or press Enter in the viewport) to enter the view state and start grooming the fibers. The fibers will be written to the geostream as a point attribute called `adnFibers`, and can be used to drive the activation of an AdnMuscle or AdnRibbonMuscle.
 5. Connect the AdnFiberGroom HDA to the input of an AdnMuscle or AdnRibbonMuscle SOP node.
 
 <figure markdown>
   ![Fiber groom minimum required setup](../images/fiber_groom_minimum_setup.png)
-  <figcaption><b>Figure 1</b>: Minimum required setup to groom the fibers and create the adnFibers point attribute. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API. </figcaption>
+  <figcaption><b>Figure 1</b>: Minimum required setup to groom the fibers and create the adnFibers point attribute. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API. </figcaption>
 </figure>
 
 > [!NOTE]
 > - If the geostream contains an `adnTendons` point attribute as tendon mask, the AdnFiberGroom HDA will be able to estimate the initial fiber directions. Otherwise, the initial fiber directions will be empty.
 > - It is recommended to place the AdnFiberGroom node after an `attribpaint` node, which is used to paint the `adnTendons` map.
 
-To simplify the creation and initial setup, AdonisFX provides two utilities: *Make Paintable* and *Make Groomable*. These utilities automate the creation of the `attribpaint` node and the AdnFiberGroom HDA.
+To simplify the creation and initial setup, Adonis provides two utilities: *Make Paintable* and *Make Groomable*. These utilities automate the creation of the `attribpaint` node and the AdnFiberGroom HDA.
 
-With the muscle geometry connected to the corresponding AdonisFX muscle SOP (i.e., AdnMuscle or AdnRibbonMuscle), select the muscle SOP node and click AdonisFX > Utils > Make Paintable. This utility will create:
+With the muscle geometry connected to the corresponding Adonis muscle SOP (i.e., AdnMuscle or AdnRibbonMuscle), select the muscle SOP node and click Adonis > Utils > Make Paintable. This utility will create:
 
 - an `attribcreate` node to define the required point attributes and assign default values, followed by
 
@@ -33,11 +33,11 @@ Both nodes are automatically named and correctly connected to the muscle SOP nod
 
 Next, paint the `adnTendons` map using the `attribpaint` node.
 
-Then, select the muscle SOP node again and click AdonisFX > Utils > Make Groomable. This utility will create the AdnFiberGroom node that computes the initial fiber directions based on the previously painted `adnTendons` map. It also allows to further groom and refine the fibers if additional adjustments are needed. The AdnFiberGroom node will be automatically named and properly connected to the muscle SOP node.
+Then, select the muscle SOP node again and click Adonis > Utils > Make Groomable. This utility will create the AdnFiberGroom node that computes the initial fiber directions based on the previously painted `adnTendons` map. It also allows to further groom and refine the fibers if additional adjustments are needed. The AdnFiberGroom node will be automatically named and properly connected to the muscle SOP node.
 
 <figure markdown>
   ![Fiber groom complete required setup](../images/fiber_groom_complete_setup.png)
-  <figcaption><b>Figure 2</b>: Complete setup after using the Make Paintable and Make Groomable utilities. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the AdonisFX deformable section is recommended to keep the network compatible with the API.</figcaption>
+  <figcaption><b>Figure 2</b>: Complete setup after using the Make Paintable and Make Groomable utilities. Using null nodes with ADN_IN_ and ADN_OUT_ prefixes to encapsulate the Adonis deformable section is recommended to keep the network compatible with the API.</figcaption>
 </figure>
 
 <figure markdown>

--- a/docs/houdini/utils/fiber_projection.md
+++ b/docs/houdini/utils/fiber_projection.md
@@ -8,7 +8,7 @@ This is useful for visualizing the resulting fiber direction on the surface of t
 To create this node, follow these steps:
 
 1. Go to the geometry context with a geometry containing non-projected `adnFibers` point attribute representing the fiber flow of the muscle. This can also be a combined geometry with a defined per-primitive piece attribute.
-2. Press TAB and navigate to the submenu AdonisFX > Utils to find the AdnFiberProjection ![AdnFiberProjection button](../../images/adn_fiber_projection.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Utils to find the AdnFiberProjection ![AdnFiberProjection button](../../images/adn_fiber_projection.png){style="width:4%"} SOP type.
 3. Connect the geometry to the first source.
 4. Cook the node and the projected `adnFibers` point attribute is written into the geostream with projected fiber directions used to drive the activation of an AdnMuscle or AdnRibbonMuscle node. However, these fiber directions should only serve as visualization guides as the input of the AdnMuscle and AdnRibbonMuscle nodes are the non-projected fiber directions.
 

--- a/docs/houdini/utils/locators.md
+++ b/docs/houdini/utils/locators.md
@@ -1,6 +1,6 @@
 # Locators
 
-AdonisFX Locators are visualizers that are meant for visualizing and measuring transform nodes which provide valuable input information for setting up the deformers. They can visualize information representing position, distance, or angle as well as velocities or accelerations represented via coloring when used in combination with Sensors.
+Adonis Locators are visualizers that are meant for visualizing and measuring transform nodes which provide valuable input information for setting up the deformers. They can visualize information representing position, distance, or angle as well as velocities or accelerations represented via coloring when used in combination with Sensors.
 
 ## AdnLocatorPosition
 
@@ -18,7 +18,7 @@ An AdnLocatorPosition will only visualize the information of the transform node 
 Only one transform will be required to create the AdnLocatorPosition. The creation process is the following:
 
  1. Go to the geometry context of the rig containing the rig setup to which the locators should be applied.
- 2. Press TAB and navigate to the submenu AdonisFX > Locators to find the AdnLocatorPosition ![AdnLocatorPosition button](../../images/adn_point_locator.png){style="width:4%"} SOP type.
+ 2. Press TAB and navigate to the submenu Adonis > Locators to find the AdnLocatorPosition ![AdnLocatorPosition button](../../images/adn_point_locator.png){style="width:4%"} SOP type.
  3. Create it and connect the AdnSensorPosition sensor to its input for visualization purposes.
  4. Go to the AdnLocatorPosition's *Input* tab and select the transform nodes from which to extract the transformation from (e.g. joints, null nodes, rivets, etc). Use the "Operator Chooser" in the locator's UI to select the correct target node containing transform information. Generally these input nodes will be located on the */obj* level as a null, joint or rivet.
  5. Adjust the Draw Output and Scale to visualize activations and scale the visualizer for the locator.
@@ -76,7 +76,7 @@ An AdnLocatorDistance will only visualize the information of the distance betwee
 Two transform nodes will be required to create an AdnLocatorDistance representing each extremity. The creation process is the following:
 
  1. Go to the geometry context of the rig containing the rig setup to which the locators should be applied.
- 2. Press TAB and navigate to the submenu AdonisFX > Locators to find the AdnLocatorDistance ![AdnLocatorDistance button](../../images/adn_distance_locator.png){style="width:4%"} SOP type.
+ 2. Press TAB and navigate to the submenu Adonis > Locators to find the AdnLocatorDistance ![AdnLocatorDistance button](../../images/adn_distance_locator.png){style="width:4%"} SOP type.
  3. Create it and connect the AdnSensorDistance sensor to its input for visualization purposes.
  4. Go to the AdnLocatorDistance's *Input* tab and select the transform nodes from which to extract the transformation from (e.g. joints, null nodes, rivets, etc). Use the "Operator Chooser" in the locator's UI to select the correct target node containing transform information. Generally these input nodes will be located on the */obj* level as a null, joint or rivet.
  5. Adjust the Draw Output and Scale to visualize activations and scale the visualizer for the locator.
@@ -136,7 +136,7 @@ An AdnLocatorRotation will only visualize the information of the connections and
 Three transform nodes will be required to create the AdnLocatorRotation. The creation process is the following:
 
  1. Go to the geometry context of the rig containing the rig setup to which the locators should be applied.
- 2. Press TAB and navigate to the submenu AdonisFX > Locators to find the AdnLocatorRotation ![AdnLocatorRotation button](../../images/adn_angle_locator.png){style="width:4%"} SOP type.
+ 2. Press TAB and navigate to the submenu Adonis > Locators to find the AdnLocatorRotation ![AdnLocatorRotation button](../../images/adn_angle_locator.png){style="width:4%"} SOP type.
  3. Create it and connect the AdnSensorRotation sensor to its input for visualization purposes.
  4. Go to the AdnLocatorRotation's *Input* tab and select the transform nodes from which to extract the transformation from (e.g. joints, null nodes, rivets, etc). Use the "Operator Chooser" in the locator's UI to select the correct target node containing transform information. Generally these input nodes will be located on the */obj* level as a null, joint or rivet.
  5. Adjust the Draw Output and Scale to visualize activations and scale the visualizer for the locator.
@@ -183,7 +183,7 @@ Three transform nodes will be required to create the AdnLocatorRotation. The cre
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
 

--- a/docs/houdini/utils/remap.md
+++ b/docs/houdini/utils/remap.md
@@ -1,25 +1,25 @@
 # AdnRemap
 
-The AdnRemap node is an AdonisFX node that aims to provide remap functionalities similarly to the remap values exposed in our sensors. This node type is typically used in an AdonisFX rig, for example, to remap the output of a sensor into a value to drive muscle activation or volume ratio gain. The objective of using AdnRemap nodes is to enhance the portability of the whole AdonisFX rig without relying on DCC specific nodes, including not only the input and output connections but also the configuration of the remap ramp attribute.
+The AdnRemap node is an Adonis node that aims to provide remap functionalities similarly to the remap values exposed in our sensors. This node type is typically used in an Adonis rig, for example, to remap the output of a sensor into a value to drive muscle activation or volume ratio gain. The objective of using AdnRemap nodes is to enhance the portability of the whole Adonis rig without relying on DCC specific nodes, including not only the input and output connections but also the configuration of the remap ramp attribute.
 
 ## How To Use
 
 An instance of this node can be created from the TAB menu:
 
 1. Go to the geometry context of the rig containing the rig setup to which the locators should be applied.
-2. Press TAB and navigate to the submenu AdonisFX > Utils to find the AdnRemap ![AdnRemap button](../../images/adn_remap.png){style="width:4%"} SOP type.
+2. Press TAB and navigate to the submenu Adonis > Utils to find the AdnRemap ![AdnRemap button](../../images/adn_remap.png){style="width:4%"} SOP type.
 3. Use detail expressions to drive the input value and to ingest the data into the desired target node. 
 
-Typically, this node will be used to remap the raw output values of AdonisFX sensors (i.e. distance, angle, velocity and acceleration) so that they are ingested into the AdonisFX locators within the desired normalized ranges. The remapped output can also be ingested directly in an AdnMuscle deformer to modulate, for example, the activation or the volume ratio.
+Typically, this node will be used to remap the raw output values of Adonis sensors (i.e. distance, angle, velocity and acceleration) so that they are ingested into the Adonis locators within the desired normalized ranges. The remapped output can also be ingested directly in an AdnMuscle deformer to modulate, for example, the activation or the volume ratio.
 
 > [!NOTE]
-> - When remapping values from an AdonisFX sensor it is advisable to remap the value output from the locator rather than the sensor to preserve consistent connection information with other DCCs.
+> - When remapping values from an Adonis sensor it is advisable to remap the value output from the locator rather than the sensor to preserve consistent connection information with other DCCs.
 
 
 ## Example
 
 <figure markdown>
-  ![AdnRemap nodes used to remap AdonisFX sensors outputs](../images/remap_example.png)
+  ![AdnRemap nodes used to remap Adonis sensors outputs](../images/remap_example.png)
   <figcaption><b>Figure 1</b>: Use case in which different AdnRemap nodes are used to configure an AdnMuscle to drive the muscle's activation and volume gain.</figcaption>
 </figure>
 
@@ -74,7 +74,7 @@ In the above setup we have the following characteristics:
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
 

--- a/docs/houdini/utils/sensors.md
+++ b/docs/houdini/utils/sensors.md
@@ -1,14 +1,14 @@
 # Sensors
 
-AdonisFX Sensors are nodes in charge of interpreting data extracted from transform nodes and compute information that can be fed into the deformers to alter their behavior. Sensors work in combination with [Locators](locators) to display the computed information in an intuitive way using coloring. The sensors produce the results in two separated outputs: the raw value result of the evaluation of the input transform nodes (e.g. *Out Angle*); and the remapped value result of the evaluation of the raw value into the existing remap ramp attributes (e.g. *Out Angle Remap*). Thanks to this, the remapped values are already adjusted within a custom range of activation that will drive the coloring of the locators and the activation of an AdnMuscle for example.
+Adonis Sensors are nodes in charge of interpreting data extracted from transform nodes and compute information that can be fed into the deformers to alter their behavior. Sensors work in combination with [Locators](locators) to display the computed information in an intuitive way using coloring. The sensors produce the results in two separated outputs: the raw value result of the evaluation of the input transform nodes (e.g. *Out Angle*); and the remapped value result of the evaluation of the raw value into the existing remap ramp attributes (e.g. *Out Angle Remap*). Thanks to this, the remapped values are already adjusted within a custom range of activation that will drive the coloring of the locators and the activation of an AdnMuscle for example.
 
 ## AdnSensorPosition
 
-AdnSensorPosition is the sensor for computing meaningful output raw values representing the velocity or acceleration of a transform node. Additionally, the sensor remaps the values of velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an AdonisFX deformer. This sensor has to work in combination with an AdnLocatorPosition both for setup and visualization. An example use case for this sensor would be applying it to the wrist connection of an arm outputting velocities while swinging.
+AdnSensorPosition is the sensor for computing meaningful output raw values representing the velocity or acceleration of a transform node. Additionally, the sensor remaps the values of velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an Adonis deformer. This sensor has to work in combination with an AdnLocatorPosition both for setup and visualization. An example use case for this sensor would be applying it to the wrist connection of an arm outputting velocities while swinging.
 
 ### How To Use
 
-An AdnSensorPosition will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorPosition for visualization purposes, which in turn feeds the AdonisFX deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
+An AdnSensorPosition will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorPosition for visualization purposes, which in turn feeds the Adonis deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
 
 <figure markdown>
   ![AdnSensorPosition velocity display on AdnLocatorPosition within a scene](../images/sensors_position.png)
@@ -18,7 +18,7 @@ An AdnSensorPosition will be in charge of computing, remapping and feeding activ
 Only one transform will be required to create the AdnSensorPosition. To create an AdnSensorPosition and connect it to an existing [AdnLocatorPosition](locators#adnlocatorposition):
 
   1. Go to the geometry context of the rig containing the rig setup to which the sensors should be applied.
-  2. Press TAB and navigate to the submenu AdonisFX > Sensors to find the AdnSensorPosition ![AdnSensorPosition button](../../images/adn_point_sensor.png){style="width:4%"} SOP type.
+  2. Press TAB and navigate to the submenu Adonis > Sensors to find the AdnSensorPosition ![AdnSensorPosition button](../../images/adn_point_sensor.png){style="width:4%"} SOP type.
   3. Create it and connect the output of the AdnSensorPosition sensor to its corresponding AdnLocatorPosition input.
   4. Go to the AdnSensorPosition's *Input* tab and select the transform nodes from which to extract the transformation from (e.g. joints, null nodes, rivets, etc). Use the "Operator Chooser" in the locator's UI to select the correct target node containing transform information. Generally these input nodes will be located on the */obj* level as a null, joint or rivet.
   5. The AdnSensorPosition is created and ready to be used with its corresponding AdnLocatorPosition.
@@ -114,11 +114,11 @@ Only one transform will be required to create the AdnSensorPosition. To create a
 
 ## AdnSensorDistance
 
-AdnSensorDistance is the sensor for computing meaningful output raw values representing the distance, velocity or acceleration between two transform nodes. Additionally, the sensor remaps the values of distance, velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an AdonisFX deformer. This sensor has to work in combination with an AdnLocatorDistance both for setup and visualization. An example use case for this sensor would be applying it to the connection made between bones which would compute the distance between two bones moving together.
+AdnSensorDistance is the sensor for computing meaningful output raw values representing the distance, velocity or acceleration between two transform nodes. Additionally, the sensor remaps the values of distance, velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an Adonis deformer. This sensor has to work in combination with an AdnLocatorDistance both for setup and visualization. An example use case for this sensor would be applying it to the connection made between bones which would compute the distance between two bones moving together.
 
 ### How To Use
 
-An AdnSensorDistance will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorDistance for visualization purposes, which in turn feeds the AdonisFX deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
+An AdnSensorDistance will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorDistance for visualization purposes, which in turn feeds the Adonis deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
 
 <figure markdown>
   ![AdnSensorDistance distance display on AdnLocatorDistance within a scene](../images/sensors_distance.png)
@@ -128,7 +128,7 @@ An AdnSensorDistance will be in charge of computing, remapping and feeding activ
 Two transforms will be required to create the AdnSensorDistance. To create an AdnSensorDistance and connect it to an existing [AdnLocatorDistance](locators#adnlocatordistance):
 
   1. Go to the geometry context of the rig containing the rig setup to which the sensors should be applied.
-  2. Press TAB and navigate to the submenu AdonisFX > Sensors to find the AdnSensorDistance ![AdnSensorDistance button](../../images/adn_distance_sensor.png){style="width:4%"} SOP type.
+  2. Press TAB and navigate to the submenu Adonis > Sensors to find the AdnSensorDistance ![AdnSensorDistance button](../../images/adn_distance_sensor.png){style="width:4%"} SOP type.
   3. Create it and connect the output of the AdnSensorDistance sensor to its corresponding AdnLocatorDistance input.
   4. Go to the AdnSensorDistance's *Input* tab and select the transform nodes from which to extract the transformation from (e.g. joints, null nodes, rivets, etc). Use the "Operator Chooser" in the locator's UI to select the correct target node containing transform information. Generally these input nodes will be located on the */obj* level as a null, joint or rivet.
   5. The AdnSensorDistance is created and ready to be used with its corresponding AdnLocatorDistance.
@@ -244,11 +244,11 @@ Two transforms will be required to create the AdnSensorDistance. To create an Ad
 
 ## AdnSensorRotation
 
-AdnSensorRotation is the sensor for computing meaningful output raw values representing the angle, angular velocity or angular acceleration between three transform nodes. Additionally, the sensor remaps the values of angle, velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an AdonisFX deformer. This sensor has to work in combination with an AdnLocatorRotation both for setup and visualization. An example use case for this sensor would be applying it to the arc connection made between bones which would compute the angle between two bones rotating.
+AdnSensorRotation is the sensor for computing meaningful output raw values representing the angle, angular velocity or angular acceleration between three transform nodes. Additionally, the sensor remaps the values of angle, velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an Adonis deformer. This sensor has to work in combination with an AdnLocatorRotation both for setup and visualization. An example use case for this sensor would be applying it to the arc connection made between bones which would compute the angle between two bones rotating.
 
 ### How To Use
 
-An AdnSensorRotation will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorRotation for visualization purposes, which in turn feeds the AdonisFX deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
+An AdnSensorRotation will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorRotation for visualization purposes, which in turn feeds the Adonis deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
 
 <figure markdown>
   ![AdnSensorRotation angle display on AdnLocatorRotation within a scene](../images/sensors_rotation.png)
@@ -258,7 +258,7 @@ An AdnSensorRotation will be in charge of computing, remapping and feeding activ
 Three transforms will be required to create the AdnSensorRotation. To create an AdnSensorRotation and connect it to an existing [AdnLocatorRotation](locators#adnlocatorrotation):
 
   1. Go to the geometry context of the rig containing the rig setup to which the sensors should be applied.
-  2. Press TAB and navigate to the submenu AdonisFX > Sensors to find the AdnSensorRotation ![AdnSensorRotation button](../../images/adn_angle_sensor.png){style="width:4%"} SOP type.
+  2. Press TAB and navigate to the submenu Adonis > Sensors to find the AdnSensorRotation ![AdnSensorRotation button](../../images/adn_angle_sensor.png){style="width:4%"} SOP type.
   3. Create it and connect the output of the AdnSensorRotation sensor to its corresponding AdnLocatorRotation input.
   4. Go to the AdnSensorRotation's *Input* tab and select the transform nodes from which to extract the transformation from (e.g. joints, null nodes, rivets, etc). Use the "Operator Chooser" in the locator's UI to select the correct target node containing transform information. Generally these input nodes will be located on the */obj* level as a null, joint or rivet.
   5. The AdnSensorRotation is created and ready to be used with its corresponding AdnLocatorRotation.
@@ -375,7 +375,7 @@ Three transforms will be required to create the AdnSensorRotation. To create an 
 
 ## Connections
 
-Connections in AdonisFX for Houdini should be handled in two ways:
-  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the AdonisFX SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
+Connections in Adonis for Houdini should be handled in two ways:
+  - Detail expression: `detail("/obj/geo1/L_adnLocatorRotation_armFlexionShape", "adnActivationRotation", 0)` where the first component should contain an API compliant naming convention and the second the detail attribute name that some of the Adonis SOP nodes output. This should be used when the requirement is for the connected geometry to cook before retrieving the detail attribute. This could be used for example to drive a parameter of the node using the activation value output from a sensor/locator.
   - Channel expression: `ch("../AdnMuscle1/envelope")` where the first component should contain an API compliant naming convention and the second the referenced channel to the parameter name. This could be used to for example connect a float attribute to drive a parameter on the node.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,18 @@
 # Introduction
 
-Welcome to the technical documentation of AdonisFX where we provide you with all the information you need to use the software in your digital characters. If you need more information or help, please do not hesitate to send an email to **adonis.support@inbibo.co.uk** with your consultation.
+Welcome to the technical documentation of Adonis where we provide you with all the information you need to use the software in your digital characters. If you need more information or help, please do not hesitate to send an email to **adonis.support@inbibo.co.uk** with your consultation.
 
 ## Key Values
 
-AdonisFX is a fast and intuitive solution for creature simulation with muscle, fat, skin and face solvers. Currently, it is implemented as a plug-in for Maya and Houdini. The key values of AdonisFX are:
+Adonis is a fast and intuitive solution for creature simulation with muscle, fat, skin and face solvers. Currently, it is implemented as a plug-in for Maya and Houdini. The key values of Adonis are:
 
-- **Fast Computation**. Typically, high quality creature simulation requires hours to compute even if running on modern hardware components. The objective of AdonisFX is to break the current limits in terms of execution times in order to deliver high quality results in seconds which is possible thanks to the latest research in the simulation field for VFX and with Inbibo's proprietary technology. 
+- **Fast Computation**. Typically, high quality creature simulation requires hours to compute even if running on modern hardware components. The objective of Adonis is to break the current limits in terms of execution times in order to deliver high quality results in seconds which is possible thanks to the latest research in the simulation field for VFX and with Inbibo's proprietary technology. 
 
-- **Quick Setup**. Preparing a creature to be simulated with realistic behavior and dynamics can be tedious and require a significant amount of time for modelers, riggers and CFX artists. Also, this process often demands a certain knowledge of physically based parameters. However, AdonisFX enables artists to set up complex creatures simulation in a short time thanks to solvers with intuitive parametrization, easy-to-use tools and AI solutions to accelerate the configuration process.
+- **Quick Setup**. Preparing a creature to be simulated with realistic behavior and dynamics can be tedious and require a significant amount of time for modelers, riggers and CFX artists. Also, this process often demands a certain knowledge of physically based parameters. However, Adonis enables artists to set up complex creatures simulation in a short time thanks to solvers with intuitive parametrization, easy-to-use tools and AI solutions to accelerate the configuration process.
 
-## Why AdonisFX?
+## Why Adonis?
 
-With AdonisFX you can:
+With Adonis you can:
 
 - integrate simulation in animation rigs,
 - integrate simulation into rigging and procedural pipelines,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,14 +2,14 @@
 
 ## Maya
 
-AdonisFX is distributed for Maya as a **standard module** (.mod). To install the module, follow these steps:
+Adonis is distributed for Maya as a **standard module** (.mod). To install the module, follow these steps:
 
-1. Download the AdonisFX package from [Inbibo’s website](https://inbibo.co.uk/downloads?tab=adonisfx).
+1. Download the Adonis package from [Inbibo’s website](https://inbibo.co.uk/downloads?tab=adonisfx).
 2. Extract the contents into any folder of your choice.
 3. Add the path to that extracted folder to the `MAYA_MODULE_PATH` environment variable (details below).
-4. Launch Maya and load AdonisFX from **Windows > Settings/Preferences > Plug-in Manager**.
+4. Launch Maya and load Adonis from **Windows > Settings/Preferences > Plug-in Manager**.
 
-When Maya starts, it evaluates all directories listed in `MAYA_MODULE_PATH` to locate module files such as `AdonisFX.mod`. Therefore, the environment variable must include the folder containing that file.
+When Maya starts, it evaluates all directories listed in `MAYA_MODULE_PATH` to locate module files such as `Adonis.mod`. Therefore, the environment variable must include the folder containing that file.
 
 There are two ways to configure `MAYA_MODULE_PATH`:
 
@@ -17,16 +17,16 @@ There are two ways to configure `MAYA_MODULE_PATH`:
 - **Method 2:** Set the value as a system-wide or user-wide environment variable
 
 > [!NOTE]
-> - AdonisFX is distributed for multiple Maya versions. If you have multiple Maya versions installed, make sure to [download](https://inbibo.co.uk/downloads?tab=adonisfx) the right AdonisFX build and configure the environment to point to the right AdonisFX version.
-> - Remember that multiple versions of AdonisFX can be installed, but only one can be loaded at a time.
+> - Adonis is distributed for multiple Maya versions. If you have multiple Maya versions installed, make sure to [download](https://inbibo.co.uk/downloads?tab=adonisfx) the right Adonis build and configure the environment to point to the right Adonis version.
+> - Remember that multiple versions of Adonis can be installed, but only one can be loaded at a time.
 
 ### Windows
 
 #### Method 1: Configure Maya.env
 
 1. The default location of the `Maya.env` file is `drive:/Users/username/Documents/maya/%MAYA_VERSION%`.
-2. Add `MAYA_MODULE_PATH = drive:/path/to/AdonisFX/folder` to the file.
-3. AdonisFX will be loaded the next time you launch Maya.
+2. Add `MAYA_MODULE_PATH = drive:/path/to/Adonis/folder` to the file.
+3. Adonis will be loaded the next time you launch Maya.
 
 > [!NOTE]
 > If you need to configure other modules, concatenate them separated by ";" characters.
@@ -35,8 +35,8 @@ There are two ways to configure `MAYA_MODULE_PATH`:
 
 1. Open the System Properties window which can be found by searching for *environment variables* in the Windows search bar.
 2. Click on *Environment Variables* and a new window will be displayed showing all the environment variables configured at the system level and for the current user.
-3. Click on *New...* button for the level that you prefer (system or user) and configure `MAYA_MODULE_PATH` with the path containing the `AdonisFX.mod` file.
-4. AdonisFX will be loaded the next time you launch Maya.
+3. Click on *New...* button for the level that you prefer (system or user) and configure `MAYA_MODULE_PATH` with the path containing the `Adonis.mod` file.
+4. Adonis will be loaded the next time you launch Maya.
 
 > [!NOTE]
 > If you need to configure other modules, concatenate them separated by ";" characters.
@@ -47,8 +47,8 @@ There are two ways to configure `MAYA_MODULE_PATH`:
 #### Method 1: Configure Maya.env
 
 1. The default location of the `Maya.env` file is `~/maya/$MAYA_VERSION`.
-2. Add `MAYA_MODULE_PATH = /path/to/AdonisFX/folder` to the file.
-3. AdonisFX will be loaded the next time you launch Maya.
+2. Add `MAYA_MODULE_PATH = /path/to/Adonis/folder` to the file.
+3. Adonis will be loaded the next time you launch Maya.
 
 > [!NOTE]
 > If you need to configure other modules, concatenate them separated by ":" characters.
@@ -58,9 +58,9 @@ There are two ways to configure `MAYA_MODULE_PATH`:
 1. From the terminal, open your preferred text editor to modify the file `~/.bashrc`.
 2. Add this command to export the environment variable:
 
-   `export MAYA_MODULE_PATH="/path/to/AdonisFX/folder:${MAYA_MODULE_PATH}"`
+   `export MAYA_MODULE_PATH="/path/to/Adonis/folder:${MAYA_MODULE_PATH}"`
 
-3. AdonisFX will be loaded the next time you launch Maya.
+3. Adonis will be loaded the next time you launch Maya.
 
 > [!NOTE]
 > If you need to configure other modules, concatenate them separated by ":" characters.
@@ -68,34 +68,34 @@ There are two ways to configure `MAYA_MODULE_PATH`:
 
 ## Houdini
 
-AdonisFX is distributed for Houdini as a **standard package** (.json). To install the package, please do the following:
+Adonis is distributed for Houdini as a **standard package** (.json). To install the package, please do the following:
 
-1. Download the AdonisFX package from [Inbibo’s website](https://inbibo.co.uk/downloads?tab=adonisfx).
+1. Download the Adonis package from [Inbibo’s website](https://inbibo.co.uk/downloads?tab=adonisfx).
 2. Extract the contents into any folder of your choice.
-3. Add the path to that extracted folder to the `HOUDINI_PACKAGE_DIR` and `ADONISFX_INSTALL_PATH` environment variables.
-4. Launch Houdini and the AdonisFX package will be automatically loaded.
+3. Add the path to that extracted folder to the `HOUDINI_PACKAGE_DIR` and `ADN_INSTALL_PATH` environment variables.
+4. Launch Houdini and the Adonis package will be automatically loaded.
 
-When Houdini starts up, it evaluates all paths pointed by the `HOUDINI_PACKAGE_DIR` environment variable to search for packages that are typically defined as JSON files. In order to allow Houdini to find AdonisFX, that environment variable has to include the path where the `AdonisFX.json` file is located.
+When Houdini starts up, it evaluates all paths pointed by the `HOUDINI_PACKAGE_DIR` environment variable to search for packages that are typically defined as JSON files. In order to allow Houdini to find Adonis, that environment variable has to include the path where the `Adonis.json` file is located.
 
-The need to set `ADONISFX_INSTALL_PATH` as well is to allow Houdini to complete the environment configuration using paths relative to the AdonisFX installation folder.
+The need to set `ADN_INSTALL_PATH` as well is to allow Houdini to complete the environment configuration using paths relative to the Adonis installation folder.
 
 In the following sections we explain how to do this for Windows and Linux.
 
 > [!NOTE]
-> - AdonisFX is distributed for multiple Houdini versions. If you have multiple Houdini versions installed, make sure to [download](https://inbibo.co.uk/downloads?tab=adonisfx) the right AdonisFX build and configure the environment to point to the right AdonisFX version.
-> - Remember that multiple versions of AdonisFX can be installed, but only one can be loaded at a time.
+> - Adonis is distributed for multiple Houdini versions. If you have multiple Houdini versions installed, make sure to [download](https://inbibo.co.uk/downloads?tab=adonisfx) the right Adonis build and configure the environment to point to the right Adonis version.
+> - Remember that multiple versions of Adonis can be installed, but only one can be loaded at a time.
 
 ### Windows
 
 1. Open the System Properties window which can be found by searching for *environment variables* in the Windows search bar.
 2. Click on *Environment Variables* and a new window will be displayed showing all the environment variables configured at the system level and for the current user.
-3. Click on *New...* button for the level that you prefer (system or user) and configure `HOUDINI_PACKAGE_DIR` with the path containing the `AdonisFX.json` file.
-4. Do the same for `ADONISFX_INSTALL_PATH`.
-5. AdonisFX will be loaded the next time you launch Houdini.
+3. Click on *New...* button for the level that you prefer (system or user) and configure `HOUDINI_PACKAGE_DIR` with the path containing the `Adonis.json` file.
+4. Do the same for `ADN_INSTALL_PATH`.
+5. Adonis will be loaded the next time you launch Houdini.
 
 > [!NOTE]
 > - If you need to configure other packages for `HOUDINI_PACKAGE_DIR`, concatenate them separated by ";" characters.
-> - For `ADONISFX_INSTALL_PATH`, only a single installation path should be provided.
+> - For `ADN_INSTALL_PATH`, only a single installation path should be provided.
 
 
 ### Linux
@@ -103,14 +103,14 @@ In the following sections we explain how to do this for Windows and Linux.
 1. From the terminal, open your preferred text editor to modify the file `~/.bashrc`.
 2. Add the command to export `HOUDINI_PACKAGE_DIR` as follows:
 
-    `export HOUDINI_PACKAGE_DIR="/path/to/AdonisFX/folder:${HOUDINI_PACKAGE_DIR}"`
+    `export HOUDINI_PACKAGE_DIR="/path/to/Adonis/folder:${HOUDINI_PACKAGE_DIR}"`
 
-3. Add also the command to export `ADONISFX_INSTALL_PATH`:
+3. Add also the command to export `ADN_INSTALL_PATH`:
 
-    `export ADONISFX_INSTALL_PATH="/path/to/AdonisFX/folder"`
+    `export ADN_INSTALL_PATH="/path/to/Adonis/folder"`
 
-4. AdonisFX will be loaded the next time you launch Houdini.
+4. Adonis will be loaded the next time you launch Houdini.
 
 > [!NOTE]
 > - If you need to configure other packages for `HOUDINI_PACKAGE_DIR`, concatenate them separated by ":" characters.
-> - For `ADONISFX_INSTALL_PATH`, only a single installation path should be provided.
+> - For `ADN_INSTALL_PATH`, only a single installation path should be provided.

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,38 +1,38 @@
 # Licensing
 
-AdonisFX requires a successful license activation for commercial use. For non-commercial and testing purposes a trial period of 30 days can be requested.
-In this page the different licensing components of AdonisFX will be explained in combination with the requirements and steps for activating the product.
+Adonis requires a successful license activation for commercial use. For non-commercial and testing purposes a trial period of 30 days can be requested.
+In this page the different licensing components of Adonis will be explained in combination with the requirements and steps for activating the product.
 
-AdonisFX supports two *Licensing Modes*:
+Adonis supports two *Licensing Modes*:
 
-- **Node-Locked Licensing:** License mode that locks AdonisFX to one particular computer with a particular hardware footprint. After the activation on a computer, using the license key on a different computer would disable the ability to activate the software.
+- **Node-Locked Licensing:** License mode that locks Adonis to one particular computer with a particular hardware footprint. After the activation on a computer, using the license key on a different computer would disable the ability to activate the software.
 - **Floating Licensing:** License mode that allows different users to request licenses from a common license pool (served by a server) avoiding the use restriction of the software to a single machine.
 
-AdonisFX also distinguishes between two *Licensing Types*:
+Adonis also distinguishes between two *Licensing Types*:
 
-- **Interactive:** License type that allows the user to use AdonisFX from the graphical interface of the software where AdonisFX was loaded. This licensing type is intended for users that want to build scenes, manipulate and interact with AdonisFX using visual and interactive feedback.
-- **Batch:** License type that allows the user to use AdonisFX from a batch script or terminal without the ability to use the graphical interface for manipulating the software. This licensing type is intended for users that want to run AdonisFX from a terminal to for example render a scene on the farm after setting the scene up using an Interactive License.
+- **Interactive:** License type that allows the user to use Adonis from the graphical interface of the software where Adonis was loaded. This licensing type is intended for users that want to build scenes, manipulate and interact with Adonis using visual and interactive feedback.
+- **Batch:** License type that allows the user to use Adonis from a batch script or terminal without the ability to use the graphical interface for manipulating the software. This licensing type is intended for users that want to run Adonis from a terminal to for example render a scene on the farm after setting the scene up using an Interactive License.
 
-To be able to activate AdonisFX it is required to purchase a `PRODUCT KEY`. Product keys can be purchased through Inbibo's official [website](https://inbibo.co.uk/pricing?tab=adonisfx). AdonisFX product keys have the following characteristics:
+To be able to activate Adonis it is required to purchase a `PRODUCT KEY`. Product keys can be purchased through Inbibo's official [website](https://inbibo.co.uk/pricing?tab=adonisfx). Adonis product keys have the following characteristics:
 
-- A `PRODUCT KEY` is associated with one single license type: Interactive or Batch. If the user wants to use AdonisFX both in Interactive and Batch mode, two separate product keys have to be purchased.
-- A product key consists of **28** alphanumeric characters separated by "-" which is provided to the user when purchasing AdonisFX through the website: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
+- A `PRODUCT KEY` is associated with one single license type: Interactive or Batch. If the user wants to use Adonis both in Interactive and Batch mode, two separate product keys have to be purchased.
+- A product key consists of **28** alphanumeric characters separated by "-" which is provided to the user when purchasing Adonis through the website: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`.
 
 ## Node-Locked Licensing
 
-Node-Locked Licensing in AdonisFX requires the activation of a `PRODUCT KEY` on one single machine. As commented before, this activation process requires the user to activate the product for batch and interactive modes separately.
+Node-Locked Licensing in Adonis requires the activation of a `PRODUCT KEY` on one single machine. As commented before, this activation process requires the user to activate the product for batch and interactive modes separately.
 
 > [!NOTE]
-> Node-Locked Licensing is the default license mode in AdonisFX. To explicitly switch to Node-Locked licensing in AdonisFX, set the environment variable `ADN_LICENSE_MODE` to `0`.
+> Node-Locked Licensing is the default license mode in Adonis. To explicitly switch to Node-Locked licensing in Adonis, set the environment variable `ADN_LICENSE_MODE` to `0`.
 
 ### Interactive
 
-Whenever activating AdonisFX for the first time for a specific DCC in interactive mode, a series of dialogs requesting information are prompted. These dialogs allow users to enter a valid `PRODUCT KEY` or to launch AdonisFX in trial mode for non-commercial purposes.
+Whenever activating Adonis for the first time for a specific DCC in interactive mode, a series of dialogs requesting information are prompted. These dialogs allow users to enter a valid `PRODUCT KEY` or to launch Adonis in trial mode for non-commercial purposes.
 
-To activate AdonisFX in Node-Locked Interactive mode:
+To activate Adonis in Node-Locked Interactive mode:
   1. Launch your DCC.
   2. Load the plug-in.
-  3. Go to AdonisFX Menu > *Activate License*. A dialog will show up with two options: *Activate* to enter a valid `PRODUCT KEY` in order to enable the full license; *Continue With Trial* to continue with the 30 day trial period.
+  3. Go to Adonis Menu > *Activate License*. A dialog will show up with two options: *Activate* to enter a valid `PRODUCT KEY` in order to enable the full license; *Continue With Trial* to continue with the 30 day trial period.
 
 <figure style="width:80%; margin-left:10%" markdown>
       ![Activation Dialog](images/licensing_activation_dialog.png)
@@ -58,7 +58,7 @@ To activate AdonisFX in Node-Locked Interactive mode:
       <figcaption><b>Figure 4</b>: Activation Retry Adding Product Key.</figcaption>
 </figure>
 
-  6. AdonisFX is activated. Restart your DCC to start using all features from AdonisFX.
+  6. Adonis is activated. Restart your DCC to start using all features from Adonis.
 
 > [!NOTE]
 > - This activation mode requires access to the internet for activating licenses.
@@ -66,53 +66,53 @@ To activate AdonisFX in Node-Locked Interactive mode:
 
 ### Batch
 
-Whenever activating AdonisFX for the first time for a specific DCC in batch mode, a product key has to be registered previously. Activating batch mode requires the use of an executable that eases the activation process of the product.
+Whenever activating Adonis for the first time for a specific DCC in batch mode, a product key has to be registered previously. Activating batch mode requires the use of an executable that eases the activation process of the product.
 
-To activate AdonisFX in Node-Locked Batch mode:
+To activate Adonis in Node-Locked Batch mode:
 
-  1. Go to `AdonisFX/bin` in the AdonisFX installation folder.
+  1. Go to `Adonis/bin` in the Adonis installation folder.
   2. Run `ActivateBatch`.
   3. Enter the `PRODUCT KEY`.
-  4. AdonisFX is activated and ready to be used.
+  4. Adonis is activated and ready to be used.
 
 ### Trial
 
-AdonisFX allows the user to use the product for **30 days** in Node-Locked Interactive mode. This means that the trial can be used using the graphical interface for one single machine at a time. The trial period requires activation which can be handled in an online or offline way.
+Adonis allows the user to use the product for **30 days** in Node-Locked Interactive mode. This means that the trial can be used using the graphical interface for one single machine at a time. The trial period requires activation which can be handled in an online or offline way.
 
-Trial licenses are intended for testing and non-commercial purposes. To use AdonisFX for commercial purposes a `PRODUCT KEY` must be purchased through Inbibo's official [website](https://inbibo.co.uk/pricing?tab=adonisfx) and activated. See the AdonisFX [End User License Agreement](https://inbibo.co.uk/legal/adonisfx-eula) for details.
+Trial licenses are intended for testing and non-commercial purposes. To use Adonis for commercial purposes a `PRODUCT KEY` must be purchased through Inbibo's official [website](https://inbibo.co.uk/pricing?tab=adonisfx) and activated. See the Adonis [End User License Agreement](https://inbibo.co.uk/legal/adonisfx-eula) for details.
 
 > [!NOTE]
 > After setting the paths for the Houdini installation, the trial will automatically start when opening Houdini.
 
 **Online Trial Activation**
 
-It will allow the user to use AdonisFX for 30 days without providing a `PRODUCT KEY`. Once that trial period is over, the user will be asked to introduce a valid product key. If not provided, then AdonisFX will not load and cannot be used.
+It will allow the user to use Adonis for 30 days without providing a `PRODUCT KEY`. Once that trial period is over, the user will be asked to introduce a valid product key. If not provided, then Adonis will not load and cannot be used.
 
-In this case, the activation does not require any input from the user. The trial period is registered automatically the first time that AdonisFX is loaded from a workstation with internet access.
+In this case, the activation does not require any input from the user. The trial period is registered automatically the first time that Adonis is loaded from a workstation with internet access.
 
 > [!NOTE]
 > This activation mode requires access to the internet.
 
 **Offline Trial Activation**
 
-It will allow the user to use AdonisFX for 30 days without providing a `PRODUCT KEY`. Once that trial period is over, the user will be asked to introduce a valid product key. If not provided, then AdonisFX will not load and cannot be used.
+It will allow the user to use Adonis for 30 days without providing a `PRODUCT KEY`. Once that trial period is over, the user will be asked to introduce a valid product key. If not provided, then Adonis will not load and cannot be used.
 
-To activate AdonisFX in Offline Node-Locked Interactive Trial mode:
+To activate Adonis in Offline Node-Locked Interactive Trial mode:
 
-  1. Go to `AdonisFX/bin` in the AdonisFX installation folder.
+  1. Go to `Adonis/bin` in the Adonis installation folder.
   2. Run `TrialOfflineRequest` with admin privileges. An XML file `TrialOfflineRequest.xml` will be generated in the same folder.
   4. Send the request file to **adonis.support@inbibo.co.uk** providing enough information to backtrack the source of the activation request.
   5. In a maximum of 24h a `TrialOfflineResponse.xml` will be returned to the source e-mail address.
-  6. Download and save the response in the same folder `AdonisFX/bin`.
-  7. Execute `TrialOfflineResponse` (also in `AdonisFX/bin`) with admin privileges.
-  8. The response will be registered and AdonisFX will be ready to be used.
+  6. Download and save the response in the same folder `Adonis/bin`.
+  7. Execute `TrialOfflineResponse` (also in `Adonis/bin`) with admin privileges.
+  8. The response will be registered and Adonis will be ready to be used.
 
 > [!NOTE]
 > This activation mode does not require access to the internet.
 
 ## Floating Licensing
 
-This section will explain how to configure, run and set-up the licensing server for leasing floating licenses when the goal is to not restrict the use of AdonisFX to one single machine. AdonisFX floating licensing system requires the use of a license server in charge of providing, dropping and handling licenses from an active lease "pool". When the amount of requested licenses surpasses the amount of licenses purchased for that floating license server no further activations of AdonisFX can be made until a lease is dropped and returned to the lease "pool" (i.e. the plug-in is unloaded or the DCC process ends).
+This section will explain how to configure, run and set-up the licensing server for leasing floating licenses when the goal is to not restrict the use of Adonis to one single machine. Adonis floating licensing system requires the use of a license server in charge of providing, dropping and handling licenses from an active lease "pool". When the amount of requested licenses surpasses the amount of licenses purchased for that floating license server no further activations of Adonis can be made until a lease is dropped and returned to the lease "pool" (i.e. the plug-in is unloaded or the DCC process ends).
 
 To be able to request leases from the license server it is necessary to activate the product with a `PRODUCT KEY` on the server side. Once activated it is required to have direct connection between the requestor instance and the licensing server to be able to balance the leases accordingly.
 
@@ -120,15 +120,15 @@ The following sections explain the steps to install and run the server, as well 
 
 ### Install Server
 
-The licensing server is provided and shipped within the installation of AdonisFX for x64 architectures and can be run on Windows or Linux. For more architectures, please visit this [page](https://wyday.com/download/).
+The licensing server is provided and shipped within the installation of Adonis for x64 architectures and can be run on Windows or Linux. For more architectures, please visit this [page](https://wyday.com/download/).
 
 The first step to be able to serve leases from the lease pool is to activate, configure and run the licensing server on a dedicated machine:
 
-1. Locate the server in `AdonisFX/licensing/turbo_float_server`.
+1. Locate the server in `Adonis/licensing/turbo_float_server`.
 2. Copy the folder to a preferred location.
 3. Copy and paste the `TurboActivate.dat` file (interactive or batch, depending on the server to install) in the same location:
-    - `AdonisFX/licensing/interactive/TurboActivate.dat` for interactive mode licenses.
-    - `AdonisFX/licensing/batch/TurboActivate.dat` for batch mode licenses.
+    - `Adonis/licensing/interactive/TurboActivate.dat` for interactive mode licenses.
+    - `Adonis/licensing/batch/TurboActivate.dat` for batch mode licenses.
 4. The content after copying the files should follow the structure in Figure 5.
 5. Before running the license server and activating the license, several elements of the `TurboFloatServer-config.xml` can be tweaked. Like for example:
     - *Connection port, thread count, lease length, logs, grace periods, and proxies*. For more information visit this [page](https://wyday.com/limelm/help/turbofloat-server/#config). Write down the configured port number for when setting up the environment variables in this [section](#run-server).
@@ -209,26 +209,26 @@ On Windows, it is also possible to install a service in charge of running the se
 
 ### Client Configuration
 
-To be able to run AdonisFX using a floating license, make sure the floating server is running and the client machine intended to use AdonisFX has direct access to the floating server. Then, configure the licensing mode and the IP address in the environment of the client machine:
+To be able to run Adonis using a floating license, make sure the floating server is running and the client machine intended to use Adonis has direct access to the floating server. Then, configure the licensing mode and the IP address in the environment of the client machine:
 
-  1. Set `ADN_LICENSE_MODE` to `1`. Make sure to apply this change before launching AdonisFX.
+  1. Set `ADN_LICENSE_MODE` to `1`. Make sure to apply this change before launching Adonis.
   2. Set `ADN_LICENSE_SERVER` for interactive licenses and `ADN_LICENSE_SERVER_BATCH` for batch licenses to `<IP-ADDRESS>:<PORT-NUMBER>` (e.g. `127.0.0.1:13`). If no port number was provided the system will default to port `13`.
 
-When launching AdonisFX in the target DCC, if the connection to the active license server could be established, it will try to obtain a valid lease and if granted it will load the plug-in.
+When launching Adonis in the target DCC, if the connection to the active license server could be established, it will try to obtain a valid lease and if granted it will load the plug-in.
 
 > [!NOTE]
-> - Make sure to configure the required environment variables before loading AdonisFX.
-> - Node-Locked Licensing is defaulted in AdonisFX meaning that if `ADN_LICENSE_MODE` is not set to `1` or not provided, then AdonisFX will attempt to load Node-Locked licenses.
+> - Make sure to configure the required environment variables before loading Adonis.
+> - Node-Locked Licensing is defaulted in Adonis meaning that if `ADN_LICENSE_MODE` is not set to `1` or not provided, then Adonis will attempt to load Node-Locked licenses.
 
 ### Save Server Tool (Optional)
 
-The first time that the client attempts to load AdonisFX with a floating license, the IP address and the port specified in the environment variables are saved in the machine. Optionally, you can execute the **SaveServer** utility to save the server information before launching the DCC process that will attempt to load AdonisFX. In some specific environments where the client machines do not have permission to store this information, using this tool with admin privileges would become a requirement.
+The first time that the client attempts to load Adonis with a floating license, the IP address and the port specified in the environment variables are saved in the machine. Optionally, you can execute the **SaveServer** utility to save the server information before launching the DCC process that will attempt to load Adonis. In some specific environments where the client machines do not have permission to store this information, using this tool with admin privileges would become a requirement.
 
 This utility works in **Windows** and **Linux** and can be used to save the server information of Interactive licenses or Batch licenses. It can be executed by providing the settings either via prompts in the terminal or via command-line arguments. Internally, the program does the following:
 
 1. Parses command-line flags and required arguments.
 2. Prompts the user if required information is missing.
-3. Locates the correct `TurboActivate.dat` file in the AdonisFX package to retrieve the necessary information to process the request.
+3. Locates the correct `TurboActivate.dat` file in the Adonis package to retrieve the necessary information to process the request.
 4. Saves the server address and port.
 5. Verifies the configuration by requesting a license lease.
 6. Drops the lease (non-critical if it fails).
@@ -241,7 +241,7 @@ This utility works in **Windows** and **Linux** and can be used to save the serv
 | `<server_port>`       | yes | License server port (1–65535). |
 | `-b`, `--batch`       | no  | Use **batch** license (default). |
 | `-i`, `--interactive` | no  | Use **interactive** license. |
-| `-d`, `--directory`   | no  | Base directory of the AdonisFX package containing the `AdonisFX` subfolder. |
+| `-d`, `--directory`   | no  | Base directory of the Adonis package containing the `Adonis` subfolder. |
 
 #### Input validation
 
@@ -258,7 +258,7 @@ About the server port:
 
 #### How To Use
 
-1. Go to AdonisFX/bin in the AdonisFX installation folder.
+1. Go to Adonis/bin in the Adonis installation folder.
 2. Run the SaveServer program using one of the following examples depending on the needs.
 
 > [!NOTE = Batch license (default)]
@@ -284,11 +284,11 @@ If the program has to be executed from a different working directory, then the d
 > [!NOTE = Using a custom base directory]
 > === Windows
 > 
-> `<ADONISFX_INSTALL_PATH>/SaveServer.exe -i -d <ADONISFX_INSTALL_PATH> 127.0.0.1 13`
+> `<ADN_INSTALL_PATH>/SaveServer.exe -i -d <ADN_INSTALL_PATH> 127.0.0.1 13`
 >
 >  === Linux
 >
-> `<ADONISFX_INSTALL_PATH>/SaveServer -i -d <ADONISFX_INSTALL_PATH> 127.0.0.1 13`
+> `<ADN_INSTALL_PATH>/SaveServer -i -d <ADN_INSTALL_PATH> 127.0.0.1 13`
 
 If the program is executed **without required arguments**, it prompts the user for the necessary inputs in this order: license product, server address and server port. This is an example session:
 
@@ -309,8 +309,8 @@ Cause:
 - `TurboActivate.dat` could not be found.
 
 Fix:
-- Run the program from `AdonisFX/bin`, or
-- Use `--directory` to point to the folder containing `AdonisFX`.
+- Run the program from `Adonis/bin`, or
+- Use `--directory` to point to the folder containing `Adonis`.
 
 **2. Failed to obtain the server handle**
 

--- a/docs/maya/api.md
+++ b/docs/maya/api.md
@@ -3,10 +3,10 @@
 ### Experimental Python API
 
 > [!NOTE]
-> - This API is experimental, and will be subject to changes in following versions of AdonisFX.
+> - This API is experimental, and will be subject to changes in following versions of Adonis.
 > - The use of this API in production applications is not supported.
 
-An experimental Python API has been developed to allow Technical Directors to implement custom Python scripts for exporting and rebuilding AdonisFX rigs programmatically.
+An experimental Python API has been developed to allow Technical Directors to implement custom Python scripts for exporting and rebuilding Adonis rigs programmatically.
 
 This API enables users to:
 - Extract the setup from an existing rig in Maya.
@@ -15,14 +15,14 @@ This API enables users to:
 
 As this API is still under active development, please do not hesitate to send an email to **adonis.support@inbibo.co.uk** to provide feedback and/or feature requests. The support and development teams will work together to incorporate user feedback and refine the implementation.
 
-The API can be found in `AdonisFX/python/adn/api/adnx.py`. 
+The API can be found in `Adonis/python/adn/api/adnx.py`. 
 The definitions can be imported with `from adn.api.adnx import *`.
 
 Since the method definitions may change before the API becomes production-ready, here are some examples showing how to use the current experimental Python API for Maya. Similar methods can be found directly in the `adnx.py` file.
 
 1. How to create a rig instance with Maya as the host: `rig = AdnRig(AdnHost.kMaya)`.
-2. How to create an AdonisFX rig component and add it to the rig (e.g. an AdnMuscle inside the rig): `muscle = AdnMuscle(rig)` and `rig.addSolver(muscle)`.
-3. How to gather data from an existing AdonisFX scene to populate the rig component entry (assuming AdnMuscle1 exists in the Maya scene): `muscle.fromNode("AdnMuscle1")`.
+2. How to create an Adonis rig component and add it to the rig (e.g. an AdnMuscle inside the rig): `muscle = AdnMuscle(rig)` and `rig.addSolver(muscle)`.
+3. How to gather data from an existing Adonis scene to populate the rig component entry (assuming AdnMuscle1 exists in the Maya scene): `muscle.fromNode("AdnMuscle1")`.
 4. How to get the dictionary containing the extracted data: `data = muscle.getData()`.
 5. How to populate the rig component from a dictionary that contains all required entries: `muscle.fromDict(data)`. The required dictionary formatting can be found in the `__init__` methods of the `AdnMuscleBase` and `AdnMuscle` classes. Modifying dictionary entries allows users to update or rebuild rigs with custom values.
 6. How to update an existing rig component in the scene after modifying its values: `muscle.update()`. This method assumes that the target AdnMuscle already exists in the scene.
@@ -30,9 +30,9 @@ Since the method definitions may change before the API becomes production-ready,
 8. How to define the execution order when extracting data from an existing scene: `rig.buildExecutionOrder()`. With an already configured scene, this deduces the correct reconstruction order required to preserve deformation and node dependency chains.
 9. How to clear a specific rig component from the scene: `muscle.clear()`.
 
-All other methods can be found in the `AdonisFX/python/adn/api/adnx.py` file.
+All other methods can be found in the `Adonis/python/adn/api/adnx.py` file.
 
-The API is the base foundation for the Import/Export tools of AdonisFX. Below is an example of exported rig data in a .json file:
+The API is the base foundation for the Import/Export tools of Adonis. Below is an example of exported rig data in a .json file:
 
 <figure markdown>
   ![Maya API Json example](images/maya_api_json_example.png)
@@ -43,7 +43,7 @@ The API is the base foundation for the Import/Export tools of AdonisFX. Below is
 > - Deformed geometry uses the `Shape` suffix to describe the "geometry" entry. This is important when moving data between DCCs, as it must adhere to the naming convention.
 > - Data such as "geometryAttachments" are represented using the name without the `Shape` suffix. This is also important for interoperability between DCCs.
 > - No context needs to be defined in the current version of the Maya API.
-> - Exported connections between AdonisFX nodes may differ depending on the DCC. This is expected due to differences between DCC applications. However, the rig will be correctly reconstructed when imported into any supported target DCC.
+> - Exported connections between Adonis nodes may differ depending on the DCC. This is expected due to differences between DCC applications. However, the rig will be correctly reconstructed when imported into any supported target DCC.
 
 ### Limitations
 

--- a/docs/maya/deformers/push.md
+++ b/docs/maya/deformers/push.md
@@ -7,7 +7,7 @@ AdnPush is a Maya deformer designed to push a surface along the direction of its
 The AdnPush deformer is easy to create and configure in Maya. It only requires a mesh to apply the node to. Following the example mentioned above, this mesh would be the skin geometry at rest.
 
 1. Select the mesh on which to apply the deformer.
-2. Press ![Push button](../../images/adn_push.png){style="width:4%"} in the AdonisFX shelf or *Push* in the AdonisFX menu, under the Create Deformers section.
+2. Press ![Push button](../../images/adn_push.png){style="width:4%"} in the Adonis shelf or *Push* in the Adonis menu, under the Create Deformers section.
 3. A message in the terminal will notify that AdnPush has been created properly.
 4. Modify the value of the *Push Length* parameter to see the result of the push deformation. Check the [Attributes](push#attributes) section to customize their configuration.
 

--- a/docs/maya/deformers/relax.md
+++ b/docs/maya/deformers/relax.md
@@ -7,7 +7,7 @@ AdnRelax is a Maya deformer designed to smooth creases and correct over-compress
 The AdnRelax deformer is easy to create and configure in Maya. It only requires the mesh to apply the relaxation onto. Typically, this mesh would be the simulated fascia or skin.
 
 1. Select the mesh on which to apply the deformer.
-2. Press ![Relax button](../../images/adn_relax.png){style="width:4%"} in the AdonisFX shelf or *Relax* in the AdonisFX menu, under the Create Deformers section.
+2. Press ![Relax button](../../images/adn_relax.png){style="width:4%"} in the Adonis shelf or *Relax* in the Adonis menu, under the Create Deformers section.
 3. A message in the terminal will notify that AdnRelax has been created properly. Increase the number of iterations to see the effect of the deformation. Check the [Attributes](relax#attributes) section to customize their configuration.
 
 ## Attributes

--- a/docs/maya/deformers/skin_merge.md
+++ b/docs/maya/deformers/skin_merge.md
@@ -16,7 +16,7 @@ To create an AdnSkinMerge deformer within a Maya scene, the following inputs mus
 
 The process to create an AdnSkinMerge deformer is:
 
-1. Press ![Skin merge button](../../images/adn_skin_merge.png){style="width:4%"} in the AdonisFX shelf or *Skin Merge* in the AdonisFX menu, under the *Deformers* submenu in the *Create* section to open the following UI.
+1. Press ![Skin merge button](../../images/adn_skin_merge.png){style="width:4%"} in the Adonis shelf or *Skin Merge* in the Adonis menu, under the *Deformers* submenu in the *Create* section to open the following UI.
 
 <figure markdown>
   ![create skin merge UI](../images/skin_merge_create.png) 
@@ -41,7 +41,7 @@ The process to create an AdnSkinMerge deformer is:
 
 Once the AdnSkinMerge deformer is created, to modify its input meshes (animation mesh list, simulation mesh list or both) do the following:
 
-1. Go to *Deformers > Skin Merge* in the AdonisFX menu, under the *Edit* section.
+1. Go to *Deformers > Skin Merge* in the Adonis menu, under the *Edit* section.
 
 2. The following UI will get displayed. Here you will see listed the current animation and simulation meshes the deformer has connected. From this UI you may freely add or remove from either list. Note that at least one element must be present in each list to be able to apply the changes. 
 
@@ -53,8 +53,8 @@ Once the AdnSkinMerge deformer is created, to modify its input meshes (animation
 3. Once everything has been set up, press the *Apply changes* button. A message in the terminal will notify you that AdnSkinMerge has been edited properly.
 
 > [!NOTE]
-> - In v2.0 of AdonisFX a new *currentTime* plug has been added to the node which will be automatically connected to the *time1.outTime* plug in Maya.
-> - The *Upgrade v1.x To v2.x* or the *Reconnect Current Time* utils in the AdonisFX menu can be used to reconnect the time plug in case it is missing in the setup.
+> - In v2.0 of Adonis a new *currentTime* plug has been added to the node which will be automatically connected to the *time1.outTime* plug in Maya.
+> - The *Upgrade v1.x To v2.x* or the *Reconnect Current Time* utils in the Adonis menu can be used to reconnect the time plug in case it is missing in the setup.
 
 ## Attributes
 

--- a/docs/maya/scripts/io.md
+++ b/docs/maya/scripts/io.md
@@ -2,23 +2,23 @@
 
 In `adn.scripts.maya.adnio` module, a set of Python functions are provided to allow users to:
 
-- Gather the AdonisFX nodes setup from the scene.
-- Clear the scene by removing all AdonisFX nodes.
-- Build the AdonisFX setup in the scene from a dictionary.
-- Import AdonisFX setup from a JSON file.
-- Export AdonisFX setup into a JSON file.
+- Gather the Adonis nodes setup from the scene.
+- Clear the scene by removing all Adonis nodes.
+- Build the Adonis setup in the scene from a dictionary.
+- Import Adonis setup from a JSON file.
+- Export Adonis setup into a JSON file.
 
 In the following sections, we provide a brief overview of how to use the utilities provided in this Python module.
 
 ## Gather Data
 
-To gather all AdonisFX nodes from the scene and store their setup into a dictionary, run this command in Python:
+To gather all Adonis nodes from the scene and store their setup into a dictionary, run this command in Python:
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.scripts.maya import adnio
 data = adnio.gather_from_scene(enabled_features)
 </code></pre>
 
-The argument `enabled_features` is optional and it is a dictionary where keys are feature names (i.e. AdonisFX solver nodes and other util nodes) and values are flags to determine if a feature has to be gathered or bypassed. If this is not provided, all features will be gathered.
+The argument `enabled_features` is optional and it is a dictionary where keys are feature names (i.e. Adonis solver nodes and other util nodes) and values are flags to determine if a feature has to be gathered or bypassed. If this is not provided, all features will be gathered.
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.utils.constants import IOFeaturesData
 enabled_features = {
@@ -39,7 +39,7 @@ enabled_features = {
 
 ## Clear All
 
-To clear all AdonisFX related nodes from the scene, run the command below in Python. This is useful for when AdonisFX data has to be imported onto a clean version of the rig.
+To clear all Adonis related nodes from the scene, run the command below in Python. This is useful for when Adonis data has to be imported onto a clean version of the rig.
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.scripts.maya import adnio
 adnio.clear_scene()
@@ -47,7 +47,7 @@ adnio.clear_scene()
 
 ## Build
 
-To build an AdonisFX setup in Python, it is required to provide the setup information in dictionary format. This dictionary data can be the value returned by the function `gather_from_scene` or the result of loading a JSON file exported previously with the function `export_data`. The code to build the AdonisFX setup is:
+To build an Adonis setup in Python, it is required to provide the setup information in dictionary format. This dictionary data can be the value returned by the function `gather_from_scene` or the result of loading a JSON file exported previously with the function `export_data`. The code to build the Adonis setup is:
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.scripts.maya import adnio
 adnio.build_from_data(data, enabled_features)
@@ -57,20 +57,20 @@ The first argument `data` is required and it is the dictionary with the mapped d
 
 ## Import
 
-To import an AdonisFX setup from a JSON file, run the command below:
+To import an Adonis setup from a JSON file, run the command below:
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.scripts.maya import adnio
 file_path = "path/to/source/file.json"
 adnio.import_data(file_path, enabled_features)
 </code></pre>
 
-The first argument `file_path` is required and it is the full path to the JSON file containing a valid AdonisFX setup definition. The second argument `enabled_features` is optional and corresponds to a dictionary where keys are feature names and values are flags to determine if a feature has to be imported or bypassed (same format used for gathering data).
+The first argument `file_path` is required and it is the full path to the JSON file containing a valid Adonis setup definition. The second argument `enabled_features` is optional and corresponds to a dictionary where keys are feature names and values are flags to determine if a feature has to be imported or bypassed (same format used for gathering data).
 
 Find more information about the use of the import feature in the [Import](../tools/importer) page.
 
 ## Export
 
-To export the AdonisFX setup in the current scene into a file, run this command:
+To export the Adonis setup in the current scene into a file, run this command:
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.scripts.maya import adnio
 file_path = "path/to/destination/file.json"

--- a/docs/maya/scripts/mirror.md
+++ b/docs/maya/scripts/mirror.md
@@ -1,12 +1,12 @@
 # Mirror
 
-The mirroring script is a Python script that allows the transfer of the AdonisFX muscle setup of an asset from one side to the other. For example, a user can complete the muscle rig for the left side of an asset and thanks to this script mirror the setup quickly and efficiently to the right side. 
+The mirroring script is a Python script that allows the transfer of the Adonis muscle setup of an asset from one side to the other. For example, a user can complete the muscle rig for the left side of an asset and thanks to this script mirror the setup quickly and efficiently to the right side. 
 
 Currently, the script allows to mirror:
 
 - **AdnMuscle deformers**, including their configurations, paintable maps, geometry targets, and connections to locators.​
-- The three types of **AdonisFX locators** (i.e. AdnLocatorPosition, AdnLocatorDistance, and AdnLocatorRotation).
-- The three types of **AdonisFX sensors** (i.e. AdnSensorPosition, AdnSensorDistance, and AdnSensorRotation).
+- The three types of **Adonis locators** (i.e. AdnLocatorPosition, AdnLocatorDistance, and AdnLocatorRotation).
+- The three types of **Adonis sensors** (i.e. AdnSensorPosition, AdnSensorDistance, and AdnSensorRotation).
 - **AdnActivation nodes**, including their input and output connections.
 
 Please, check this [section](#limitations) to know more about the current limitations.
@@ -44,7 +44,7 @@ In order to use the mirroring script, the rig must meet the following requiremen
 
 2. Select all geometries from the source side that have an AdnMuscle deformer applied and need to be mirrored.
 
-3. Add to the selection all the AdonisFX locators from the same source side that need to be mirrored. Note that sensors and activation nodes (as not being DAG objects) do not need to be added to the selection. The Mirror Tool will automatically handle their mirroring.
+3. Add to the selection all the Adonis locators from the same source side that need to be mirrored. Note that sensors and activation nodes (as not being DAG objects) do not need to be added to the selection. The Mirror Tool will automatically handle their mirroring.
 
 <figure style="width:90%; margin-left:5%" markdown>
   ![Mirror Script Selection](../images/mirror_tool_02.png)

--- a/docs/maya/scripts/turbo.md
+++ b/docs/maya/scripts/turbo.md
@@ -1,6 +1,6 @@
 # AdnTurbo
 
-The AdnTurbo script is a Python script that automates the setup of an AdonisFX rig on a clean asset. It configures the following layers in sequence:
+The AdnTurbo script is a Python script that automates the setup of an Adonis rig on a clean asset. It configures the following layers in sequence:
 
 - **Muscle layer**  
 - **Locators and Sensors**
@@ -28,7 +28,7 @@ def apply_turbo(
     locators_group_name=None,       # str: group name for locators and rivet nodes
     create_locators_group=False,    # bool: auto-create locators_group_name if it does not exist
     space_scale=1.0,                # float: simulation scale factor
-    force=False,                    # bool: remove existing AdonisFX nodes
+    force=False,                    # bool: remove existing Adonis nodes
     report_data=None                # dict: collects errors and warnings
 )
 </code></pre>
@@ -42,7 +42,7 @@ To configure at least the muscle layer, the following inputs are required:
 - **mummies**: one or more skeletal mesh to drive the muscle simulation.
 - **muscles**: one or more meshes representing muscles.
 
-When these two inputs are provided, the muscle layer will be completely configured including AdonisFX locators and sensors.
+When these two inputs are provided, the muscle layer will be completely configured including Adonis locators and sensors.
 
 To configure the downstream layers, the following inputs have to be provided:
 
@@ -70,7 +70,7 @@ In this section we provide a brief overview of the arguments of the `apply_turbo
 | **locators_group_name**   | Optional | string         | None  | Name of the group where the locators and rivets will be placed. |
 | **create_locators_group** | Optional | bool           | False | If True and `locators_group_name` is provided, the group is created if it does not exist. |
 | **space_scale**           | Optional | float          | 1.0   | Factor to scale simulation space. It will be set to the space scale attribute of all the solvers created. |
-| **force**                 | Optional | bool           | False | If True, deletes all existing AdonisFX nodes before executing to create the new nodes from a clean scene. Note that auxiliary nodes (e.g. rivets) or meshes created by an existing AdnGlue node will not be deleted. |
+| **force**                 | Optional | bool           | False | If True, deletes all existing Adonis nodes before executing to create the new nodes from a clean scene. Note that auxiliary nodes (e.g. rivets) or meshes created by an existing AdnGlue node will not be deleted. |
 | **report_data**           | Optional | dictionary     | None  | A dictionary (`{"errors": [], "warnings": []}`) to capture any issues during execution. |
 
 ## How to use
@@ -162,7 +162,7 @@ for warn in report_data["warnings"]:
 > [!NOTE]
 > - Note that the whole AdnTurbo can be undone.
 > - If multiple geometries or groups share the same name in different groups (e.g. group1|geo and group2|geo, group1|group3 and group2|group3), providing the full DAG path will be required.
-> - If there are AdonisFX nodes in the scene and the `force` argument is set to `False` the AdnTurbo script will generate an error in `report_data` indicating to clear the scene or to run the script again with `force=True` to automatically delete all the AdonisFX nodes.
+> - If there are Adonis nodes in the scene and the `force` argument is set to `False` the AdnTurbo script will generate an error in `report_data` indicating to clear the scene or to run the script again with `force=True` to automatically delete all the Adonis nodes.
 > - Fascia and fat meshes must have the same topology for the AdnFat deformer to be created by AdnTurbo.
 > - AdnTurbo can also be executed with the **AdnTurbo Tool**. For more details, please refer to the [AdnTurbo Tool page](../tools/turbo_tool).
 
@@ -171,7 +171,7 @@ for warn in report_data["warnings"]:
 As a result of executing the script by providing the geometries for all the layers, the following nodes will be created:
 
 - An AdnMuscle for each muscle geometry with the mummy geometries as targets.
-- An AdonisFX locator and sensor for each AdnMuscle to drive the muscle activation.
+- An Adonis locator and sensor for each AdnMuscle to drive the muscle activation.
 - An AdnGlue node (including its glue output geometry) with all the muscles as inputs.
 - An AdnSkin node for the fascia geometry with the mummy and glue geometries as targets.
 - An AdnRelax node applied on top of the fascia AdnSkin.
@@ -182,6 +182,6 @@ As a result of executing the script by providing the geometries for all the laye
 ## Limitations
 
 - The glue layer cannot be bypassed. This means that if the `fascia` argument is provided, the `glue` flag must be `True` for the script to complete successfully.
-- If the `force` flag is set to `True` the script will automatically remove all the AdonisFX nodes from the scene (if any). However, other auxiliary nodes created in previous executions of the script will not be removed (i.e. glue output geometry, rivet nodes).
+- If the `force` flag is set to `True` the script will automatically remove all the Adonis nodes from the scene (if any). However, other auxiliary nodes created in previous executions of the script will not be removed (i.e. glue output geometry, rivet nodes).
 - The default values that the AdnTurbo script will use to configure each deformer cannot be customized.
 - AdnTurbo does not support namespaces in object paths.

--- a/docs/maya/simple_setup.md
+++ b/docs/maya/simple_setup.md
@@ -1,6 +1,6 @@
 # A Simple Setup
 
-This page is dedicated to explain, step by step, a simple process of creating and setting the main AdonisFX solvers and deformers in Maya. The scenarios presented here are intended to provide the minimum required configurations to obtain plausible results.
+This page is dedicated to explain, step by step, a simple process of creating and setting the main Adonis solvers and deformers in Maya. The scenarios presented here are intended to provide the minimum required configurations to obtain plausible results.
 
 ## AdnMuscle
 
@@ -18,7 +18,7 @@ In this case the proposed example is to simulate a biceps in an animated full bo
 
 ### Create Deformer
 
-To create the AdnMuscle deformer select the mesh of the muscle, then press the ![AdnMuscle](../images/adn_muscle.png){style="width:4%"} shelf button or go to AdonisFX Menu > *Solvers* > *Muscle*. This will assign the AdnMuscle deformer to the selected muscle.
+To create the AdnMuscle deformer select the mesh of the muscle, then press the ![AdnMuscle](../images/adn_muscle.png){style="width:4%"} shelf button or go to Adonis Menu > *Solvers* > *Muscle*. This will assign the AdnMuscle deformer to the selected muscle.
 
 To create the AdnMuscle deformer with some initial specialization, double-click the shelf button or press the option box in the menu item. This will display a pop-up window that will allow doing some initial specialization, as well as creating the deformer with a custom name. Once all data has been provided press the *Create* button and the deformer will get created.
 
@@ -27,7 +27,7 @@ To create the AdnMuscle deformer with some initial specialization, double-click 
   <figcaption><b>Figure 2</b>: AdnMuscle custom creation UI.</figcaption>
 </figure>
 
-In order to add attachment constraints to the muscle select the targets (joints, geometries or both), then the muscle with the AdnMuscle applied and finally press the ![add target](images/adn_add_target.png){style="width:4%"} button or *Add Targets* in the AdonisFX menu from the Edit Muscle submenu.
+In order to add attachment constraints to the muscle select the targets (joints, geometries or both), then the muscle with the AdnMuscle applied and finally press the ![add target](images/adn_add_target.png){style="width:4%"} button or *Add Targets* in the Adonis menu from the Edit Muscle submenu.
 
 Additionally, target geometries that have been added to an AdnMuscle deformer can also be used to define Slide On Geometry Constraints. This constraint type is recommended for muscles in the limbs of the character to better follow the animation.
 
@@ -35,11 +35,11 @@ Additionally, target geometries that have been added to an AdnMuscle deformer ca
 > - Attachments to geometry and slide on geometry constraints are meant to simulate muscle-to-bone and muscle-to-muscle interactions.
 > - For muscle-to-muscle interactions, only unidirectional relationships are supported. This means that having muscles A and B, it is possible to assign A as target of B or B as target of A, but not the two at the same time.
 
-Optionally, add Slide On Segment Constraints. This constraint works in a similar way to Slide On Geometry Constraints, however, instead of providing a geometry, a pair of joints of the rig will be specified representing the segment the muscle will slide on. Selecting first the two joints of the rig (shoulder and elbow) and then the muscle geometry, go to AdonisFX Menu > Muscle > *Add Slide On Segment Constraint*.
+Optionally, add Slide On Segment Constraints. This constraint works in a similar way to Slide On Geometry Constraints, however, instead of providing a geometry, a pair of joints of the rig will be specified representing the segment the muscle will slide on. Selecting first the two joints of the rig (shoulder and elbow) and then the muscle geometry, go to Adonis Menu > Muscle > *Add Slide On Segment Constraint*.
 
 ### Paint Weights
 
-Once the AdnMuscle deformer is properly created it is possible now to paint its weights to correctly set up the deformer properties. To do so, select the simulated mesh and press the ![paint tool](images/adn_paint_tool.png){style="width:4%"} shelf button or go to AdonisFX Menu > *Paint Tool*.
+Once the AdnMuscle deformer is properly created it is possible now to paint its weights to correctly set up the deformer properties. To do so, select the simulated mesh and press the ![paint tool](images/adn_paint_tool.png){style="width:4%"} shelf button or go to Adonis Menu > *Paint Tool*.
 
 Start by painting attachment weights, painting the influence for each target by selecting the corresponding target from the list and painting its desired influence.
 
@@ -88,14 +88,14 @@ Finally, paint Slide On Segment or Slide On Geometry Constraints (if added). It 
 
 To have the muscle changing and responding to external inputs (i.e. the flexion of the arm), AdnSensorRotation can be added to drive the activation of the muscle. 
 
-To do this, first create a rotation locator and sensor to compute the elbow angle. Both elements can be created by selecting the three joints from which to create the rotation locator and sensor (shoulder, elbow and wrist joints) and directly click on the ![adnRotationSensor](../images/adn_angle_sensor.png){style="width:4%"} shelf button or go to AdonisFX Menu > Sensors (on the *Create* group) > *Rotation*. With this, both a locator and its corresponding sensor will get created at the same time.
+To do this, first create a rotation locator and sensor to compute the elbow angle. Both elements can be created by selecting the three joints from which to create the rotation locator and sensor (shoulder, elbow and wrist joints) and directly click on the ![adnRotationSensor](../images/adn_angle_sensor.png){style="width:4%"} shelf button or go to Adonis Menu > Sensors (on the *Create* group) > *Rotation*. With this, both a locator and its corresponding sensor will get created at the same time.
 
 <figure markdown>
   ![Rotation locator and sensor setup in elbow](images/simple_setup_muscle_06.png)
   <figcaption><b>Figure 9</b>: Rotation locator and sensor setup in elbow.</figcaption>
 </figure>
 
-Now that the sensor is created it has to be connected to the deformer. To do so, make use of the Connection Editor, which must be opened from the AdonisFX Menu > Sensors (on the *Edit* group) > *Connection Editor*.
+Now that the sensor is created it has to be connected to the deformer. To do so, make use of the Connection Editor, which must be opened from the Adonis Menu > Sensors (on the *Edit* group) > *Connection Editor*.
 
 With the Connection Editor opened, select the locator from the scene and press the *Reload Left* button, then select the simulated mesh and press the *Reload Right* button. The list widgets will refresh with the respective connectable attributes. Select the *activationAngle* attribute from the locator and the *activation* attribute from the deformer, and click *Make Connection*.
 
@@ -124,7 +124,7 @@ In this case a planar muscle will be simulated corresponding to a biceps, which 
 
 ### Create Deformer
 
-Similar to AdnMuscle, create the AdnRibbonMuscle deformer by selecting the mesh to deform (the biceps muscle) and then pressing the ![AdnRibbonMuscle](../images/adn_ribbon_muscle.png){style="width:4%"} shelf button or go to AdonisFX Menu > *Solvers* > *Ribbon Muscle*.
+Similar to AdnMuscle, create the AdnRibbonMuscle deformer by selecting the mesh to deform (the biceps muscle) and then pressing the ![AdnRibbonMuscle](../images/adn_ribbon_muscle.png){style="width:4%"} shelf button or go to Adonis Menu > *Solvers* > *Ribbon Muscle*.
 
 To create the AdnRibbonMuscle deformer with some initial specialization, double-click the shelf button or press the option box in the menu item. This will display a pop-up window that will allow doing some initial specialization, as well as creating the deformer with a custom name. Once all data has been provided press the *Create* button and the deformer will get created.
 
@@ -133,7 +133,7 @@ To create the AdnRibbonMuscle deformer with some initial specialization, double-
   <figcaption><b>Figure 12</b>: AdnRibbonMuscle custom creation UI.</figcaption>
 </figure>
 
-In order to add attachment constraints to the ribbon muscle select the targets (joints, geometries or both), then the muscle with the AdnRibbonMuscle applied and finally press the ![add target](images/adn_add_target.png){style="width:4%"} button or *Add Targets* in the AdonisFX menu from the Edit Muscle submenu.
+In order to add attachment constraints to the ribbon muscle select the targets (joints, geometries or both), then the muscle with the AdnRibbonMuscle applied and finally press the ![add target](images/adn_add_target.png){style="width:4%"} button or *Add Targets* in the Adonis menu from the Edit Muscle submenu.
 
 Additionally, target geometries that have been added to an AdnRibbonMuscle deformer can also be used to define Slide On Geometry Constraints. This constraint type is recommended for muscles in the limbs of the character to better follow the animation.
 
@@ -141,11 +141,11 @@ Additionally, target geometries that have been added to an AdnRibbonMuscle defor
 > - Attachments to geometry and slide on geometry constraints are meant to simulate muscle-to-bone and muscle-to-muscle interactions.
 > - For muscle-to-muscle interactions, only unidirectional relationships are supported. This means that having muscles A and B, it is possible to assign A as target of B or B as target of A, but not the two at the same time.
 
-Optionally, add Slide On Segment Constraints. This constraint works in a similar way to Slide On Geometry Constraints, however, instead of providing a geometry a pair of joints of the rig can be specified representing the segment the muscle will slide on. Selecting first the two joints of the rig (shoulder and elbow) and then the muscle geometry, go to AdonisFX Menu > Muscle > *Add Slide On Segment Constraint*.
+Optionally, add Slide On Segment Constraints. This constraint works in a similar way to Slide On Geometry Constraints, however, instead of providing a geometry a pair of joints of the rig can be specified representing the segment the muscle will slide on. Selecting first the two joints of the rig (shoulder and elbow) and then the muscle geometry, go to Adonis Menu > Muscle > *Add Slide On Segment Constraint*.
 
 ### Paint Weights
 
-Once the ribbon muscle deformer is properly created it is possible now to paint its weights to correctly set up the deformer properties. To do so, select the simulated mesh and press the ![paint tool](images/adn_paint_tool.png){style="width:4%"} shelf button or go to AdonisFX Menu > *Paint Tool*.
+Once the ribbon muscle deformer is properly created it is possible now to paint its weights to correctly set up the deformer properties. To do so, select the simulated mesh and press the ![paint tool](images/adn_paint_tool.png){style="width:4%"} shelf button or go to Adonis Menu > *Paint Tool*.
 
 Start by painting attachment weights, painting the influence for each target by selecting the corresponding target from the list and painting its desired influence.
 
@@ -211,9 +211,9 @@ The AdnGlue node will take all the simulated muscles provided as inputs and gene
 
 ### Create Node
 
-To create the AdnGlue node, select the simulated muscles and press the ![AdnGlue](../images/adn_glue.png){style="width:4%"} shelf button or go to AdonisFX Menu > *Solvers* > *Glue*. This will connect the selected muscles to the inputs plug of the AdnGlue node and create a combined output mesh as the result of the simulation.
+To create the AdnGlue node, select the simulated muscles and press the ![AdnGlue](../images/adn_glue.png){style="width:4%"} shelf button or go to Adonis Menu > *Solvers* > *Glue*. This will connect the selected muscles to the inputs plug of the AdnGlue node and create a combined output mesh as the result of the simulation.
 
-After the node creation, input muscles can be added or removed from the existing AdnGlue by pressing AdonisFX > Glue > *Add Inputs* or AdonisFX > Glue > *Remove Inputs* respectively.
+After the node creation, input muscles can be added or removed from the existing AdnGlue by pressing Adonis > Glue > *Add Inputs* or Adonis > Glue > *Remove Inputs* respectively.
 
 The *Max Glue Distance* attribute is set to 0.0 by default. Therefore, for the glue constraints to take effect, this value must be adjusted. We recommend enabling the debugger and selecting the *Glue Constraints* option to inspect the connections created based on the specified *Max Glue Distance*.
 
@@ -225,7 +225,7 @@ The *Max Glue Distance* attribute is set to 0.0 by default. Therefore, for the g
 ### Paint Weights
 
 > [!NOTE]
-> AdnGlue requires the use of the Maya Paint tool (not the AdonisFX paint tool) for the paintable weights setup.
+> AdnGlue requires the use of the Maya Paint tool (not the Adonis paint tool) for the paintable weights setup.
 
 Once the AdnGlue node is properly created, you can use Maya Paint Tool to paint its weights and correctly set up the node properties. With the *Max Glue Distance* previously adjusted, the default values of the paintable maps already allow the node to compute the glue constraints.
 
@@ -275,7 +275,7 @@ The AdnFat deformer will get applied to the second selected mesh which will beco
 
 ### Create Deformer
 
-To create the AdnFat deformer first select the base mesh and then the fat tissue mesh. Then press the ![AdnFat](../images/adn_fat.png){style="width:4%"} shelf button or go to AdonisFX Menu > *Fat*.
+To create the AdnFat deformer first select the base mesh and then the fat tissue mesh. Then press the ![AdnFat](../images/adn_fat.png){style="width:4%"} shelf button or go to Adonis Menu > *Fat*.
 
 To create the AdnFat deformer with some initial specialization, double-click the shelf button or press the option box in the menu item. This will display a pop-up window that will allow doing some initial specialization, as well as creating the deformer with a custom name. Once all data has been provided press the *Create* button and the deformer will get created.
 
@@ -289,7 +289,7 @@ After basic configuration, to alter the dynamics of the fat layer (e.g. adding o
 ### Paint Weights
 
 > [!NOTE]
-> AdnFat requires the use of the Maya Paint tool (not the AdonisFX paint tool) for the paintable weights setup.
+> AdnFat requires the use of the Maya Paint tool (not the Adonis paint tool) for the paintable weights setup.
 
 With the default paint setup provided when creating a new AdnFat, the simulation should already create plausible results. However, below we walk you through the three main maps that can be altered to modify the behavior of the fat simulation.
 
@@ -322,7 +322,7 @@ The AdnSkin deformer will get applied to the last mesh which will become the sim
 
 ### Create Deformer
 
-To create the AdnSkin deformer select one or more target meshes (optional, they can be added later) and then the skin mesh. Then press the ![AdnSkin](../images/adn_skin.png){style="width:4%"} shelf button or go to AdonisFX Menu > *Skin*.
+To create the AdnSkin deformer select one or more target meshes (optional, they can be added later) and then the skin mesh. Then press the ![AdnSkin](../images/adn_skin.png){style="width:4%"} shelf button or go to Adonis Menu > *Skin*.
 
 To create the AdnSkin deformer with some initial specialization, double-click the shelf button or press the option box in the menu item. This will display a pop-up window that will allow doing some initial specialization, as well as creating the deformer with a custom name. Once all data has been provided press the *Create* button and the deformer will get created.
 
@@ -333,7 +333,7 @@ To create the AdnSkin deformer with some initial specialization, double-click th
 
 ### Paint Weights
 
-Once the AdnSkin deformer is properly created it is possible now to paint its weights to correctly set up the deformer properties. To do so, select the simulated mesh and press the ![paint tool](images/adn_paint_tool.png){style="width:4%"} shelf button or go to AdonisFX Menu > *Paint Tool*.
+Once the AdnSkin deformer is properly created it is possible now to paint its weights to correctly set up the deformer properties. To do so, select the simulated mesh and press the ![paint tool](images/adn_paint_tool.png){style="width:4%"} shelf button or go to Adonis Menu > *Paint Tool*.
 
 Start by painting *Soft Constraints* by selecting the option from the attribute enumerator. Flood this map with a low value of 0.45 to have a uniform distribution of soft constraints. This will help the skin to follow the target mesh.
 
@@ -366,13 +366,13 @@ To create a basic scenario using the AdnRelax deformer, start with a scene with 
 To create the AdnRelax deformer:
 
 1. Select the mesh to apply the deformer onto.
-2. Press the ![AdnRelax](../images/adn_relax.png){style="width:4%"} shelf button or go to AdonisFX Menu > Deformers > *Relax*.
+2. Press the ![AdnRelax](../images/adn_relax.png){style="width:4%"} shelf button or go to Adonis Menu > Deformers > *Relax*.
 3. Increase the number of iterations to see the effect of the relaxation algorithm.
 
 ### Paint Weights
 
 > [!NOTE]
-> AdnRelax requires the use of the Maya Paint tool (not the AdonisFX paint tool) for the paintable weights setup.
+> AdnRelax requires the use of the Maya Paint tool (not the Adonis paint tool) for the paintable weights setup.
 
 The AdnRelax paintable maps are flooded to 1.0 by default because they act as multipliers for the main relax attributes (i.e., *Smooth*, *Relax*, *Push In Ratio*, and *Push Out Ratio*). Therefore, the relaxation algorithm will be applied uniformly over the entire mesh unless the maps are adjusted.
 
@@ -412,7 +412,7 @@ A good example of a use case for the AdnPush deformer is to generate the interna
 To create the AdnPush deformer:
 
 1. Select the mesh to apply the deformer onto.
-2. Press the ![AdnPush](../images/adn_push.png){style="width:4%"} shelf button or go to AdonisFX Menu > Deformers > *Push*.
+2. Press the ![AdnPush](../images/adn_push.png){style="width:4%"} shelf button or go to Adonis Menu > Deformers > *Push*.
 3. Set a negative value to the *Push Length* attribute to apply the push effect inwards (e.g. -2.0).
 
 <figure markdown>
@@ -425,7 +425,7 @@ Keeping the muscle layer visible is helpful to drive the configuration of the Ad
 ### Paint Weights
 
 > [!NOTE]
-> AdnPush requires the use of the Maya Paint tool (not the AdonisFX paint tool) for the paintable weights setup.
+> AdnPush requires the use of the Maya Paint tool (not the Adonis paint tool) for the paintable weights setup.
 
 The *push multiplier* and *weights* maps are flooded to 1.0 by default. The push multiplier is meant to modulate the amount of push across the entire mesh as it is the map that multiplies the global *Push Length* at each point. In the example with the muscle layer visible, this map can be tweaked to remove the intersections.
 
@@ -456,7 +456,7 @@ The AdnSkinMerge deformer will be applied to the final mesh which will be the re
 
 ### Create Deformer
 
-To create the AdnSkinMerge deformer press the ![AdnSkinMerge](../images/adn_skin_merge.png){style="width:4%"} shelf button or go to *AdonisFX Menu* > *Deformers* (on the *Create* group) > *Skin Merge*.
+To create the AdnSkinMerge deformer press the ![AdnSkinMerge](../images/adn_skin_merge.png){style="width:4%"} shelf button or go to *Adonis Menu* > *Deformers* (on the *Create* group) > *Skin Merge*.
 
 With this action the Create Skin Merge UI will open, allowing to add all the required elements to create the deformer. To add the required meshes select the mesh in the scene and press the corresponding *Add Selected* button. You may also set up a custom name and initialization time in this window before creating the deformer. Make sure the initialization time corresponds to the start time where all the geometries are in rest pose.
 
@@ -470,7 +470,7 @@ When everything has been properly set up, press the *Create* button to create th
 ### Paint Weights
 
 > [!NOTE]
-> AdnSkinMerge requires the use of the Maya Paint tool (not the AdonisFX paint tool) for the paintable weights setup.
+> AdnSkinMerge requires the use of the Maya Paint tool (not the Adonis paint tool) for the paintable weights setup.
 
 Once the AdnSkinMerge deformer is created the weights can be painted to blend the animation and simulation meshes into the final mesh.
 
@@ -509,7 +509,7 @@ All these meshes must have the same number of vertices and correspond to the sam
 
 To create the AdnSimshape deformer it is required to select first the rest mesh and then the animated mesh. In this scenario, the animated mesh will be used as the simulated mesh.
 
-Press the ![AdnSimshape](../images/adn_simshape.png){style="width:4%"} shelf button or go to AdonisFX Menu > *Simshape*.
+Press the ![AdnSimshape](../images/adn_simshape.png){style="width:4%"} shelf button or go to Adonis Menu > *Simshape*.
 
 To create the AdnSimshape deformer with some initial specialization, double-click the shelf button or press the option box in the menu item. This will display a pop-up window that will allow doing some initial specialization, as well as creating the deformer with a custom name. Once all data has been provided press the *Create* button and the deformer will get created.
 
@@ -518,12 +518,12 @@ To create the AdnSimshape deformer with some initial specialization, double-clic
   <figcaption><b>Figure 42</b>: AdnSimshape deformer creation scenario.</figcaption>
 </figure>
 
-To add the deformation mesh to the deformer first select the deformation mesh, then the simulated mesh (which is the animation mesh) and then go to AdonisFX Menu > Simshape (on the *Edit* group) > Add *Deform Mesh*. A message will notify that the addition of the rest mesh has been done correctly.
+To add the deformation mesh to the deformer first select the deformation mesh, then the simulated mesh (which is the animation mesh) and then go to Adonis Menu > Simshape (on the *Edit* group) > Add *Deform Mesh*. A message will notify that the addition of the rest mesh has been done correctly.
 
 ### Paint Weights
 
 > [!NOTE]
-> AdnSimshape requires the use of the Maya Paint tool (not the AdonisFX paint tool) for the paintable weights setup.
+> AdnSimshape requires the use of the Maya Paint tool (not the Adonis paint tool) for the paintable weights setup.
 
 In the case of the AdnSimshape, use the Maya Paint tool to set up and paint its paintable weight attributes. The most important paintable map is the *Attraction Force* as this is the value that dictates how much of each simulated vertex should follow the animation. This value is flooded by default to 1.0, meaning that by default the simulated mesh will follow the animation completely, without displaying dynamics.
 
@@ -544,9 +544,9 @@ After painting similar weights to the ones displayed and pressing playback to ch
 
 To further have a realistic depiction of facial dynamics, facial muscle activations can be simulated. The AdnSimshape deformer has two methods of handling muscle activations:
 
- - AdonisFX Muscle Patches file.
+ - Adonis Muscle Patches file.
  - Edge Evaluator Node.
 
-Refer to this [section](solvers/simshape#muscle-activations) to see how to use Muscle Patches files. However, in this example, it is taken advantage of the AdnEdgeEvaluator Node. To create this node, select the rest mesh, then the deformation mesh, and then go to AdonisFX Menu > Nodes > *Edge Evaluator*. Then, once created, connect it to the AdnSimshape deformer via AdonisFX Menu > Simshape (on the *Edit* group) > *Connect Activations Plug*.
+Refer to this [section](solvers/simshape#muscle-activations) to see how to use Muscle Patches files. However, in this example, it is taken advantage of the AdnEdgeEvaluator Node. To create this node, select the rest mesh, then the deformation mesh, and then go to Adonis Menu > Nodes > *Edge Evaluator*. Then, once created, connect it to the AdnSimshape deformer via Adonis Menu > Simshape (on the *Edit* group) > *Connect Activations Plug*.
 
-In the attribute editor of the AdnSimshape deformer, under the *Muscles Activation* section, the *Plug Values* will be enabled as a new valid *Activation Mode* option. To better visualize activations, press the ![AdnSimshapeDebugger](images/adn_simshape_debugger.png){style="width:4%"} shelf button or go to AdonisFX Menu > Simshape (on the *Edit* group) > *Activations Debugger*.
+In the attribute editor of the AdnSimshape deformer, under the *Muscles Activation* section, the *Plug Values* will be enabled as a new valid *Activation Mode* option. To better visualize activations, press the ![AdnSimshapeDebugger](images/adn_simshape_debugger.png){style="width:4%"} shelf button or go to Adonis Menu > Simshape (on the *Edit* group) > *Activations Debugger*.

--- a/docs/maya/solvers/fat.md
+++ b/docs/maya/solvers/fat.md
@@ -20,7 +20,7 @@ To create an AdnFat deformer within a Maya scene, the following inputs must be p
 The process to create an AdnFat deformer is:
 
 1. Select the **Base Mesh**, then the **Fat Mesh**.
-2. Press ![Fat button](../../images/adn_fat.png){style="width:4%"} in the AdonisFX shelf or *Fat* in the AdonisFX menu, under the Create Solvers section. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+2. Press ![Fat button](../../images/adn_fat.png){style="width:4%"} in the Adonis shelf or *Fat* in the Adonis menu, under the Create Solvers section. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
 3. A message in the console will notify you that AdnFat has been created properly, meaning that it is ready to simulate. If an error occurs, a dialog will be prompted. Check the next section to customize their configuration.
 
 ## Attributes
@@ -45,7 +45,7 @@ The process to create an AdnFat deformer is:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -190,13 +190,13 @@ To enable the debugger the *Debug* checkbox must be marked. To select the specif
 
 ### Base Mesh
 
-Once the AdnFat deformer is created, it is possible to add and remove the base mesh thanks to some utilities available in the AdonisFX menu.
+Once the AdnFat deformer is created, it is possible to add and remove the base mesh thanks to some utilities available in the Adonis menu.
 
 - **Add Base Mesh**:
     1. Select the geometry to be assigned as base mesh to the AdnFat.
     2. Select the geometry that has the AdnFat deformer applied.
-    3. Press the *Add Base Mesh* item in the AdonisFX menu from the Edit Fat submenu.
+    3. Press the *Add Base Mesh* item in the Adonis menu from the Edit Fat submenu.
 - **Remove Base Mesh**:
     1. Select the geometry currently assigned as base mesh to the AdnFat. This step is optional.
     2. Select the geometry that has the AdnFat deformer applied.
-    3. Press the *Remove Base Mesh* item in the AdonisFX menu from the Edit Fat submenu.
+    3. Press the *Remove Base Mesh* item in the Adonis menu from the Edit Fat submenu.

--- a/docs/maya/solvers/glue.md
+++ b/docs/maya/solvers/glue.md
@@ -26,7 +26,7 @@ To create an AdnGlue node within a Maya scene, the following inputs must be prov
 The process to create an AdnGlue node is:
 
 1. Select the Input Geometries.
-2. Press ![Glue button](../../images/adn_glue.png){style="width:4%"} in the AdonisFX shelf or the Glue action in the AdonisFX’s Solvers menu, under the Create section. 
+2. Press ![Glue button](../../images/adn_glue.png){style="width:4%"} in the Adonis shelf or the Glue action in the Adonis’ Solvers menu, under the Create section. 
 3. A message in the terminal will notify you that AdnGlue has been created properly, meaning that it is ready to simulate with default settings. Check the next section to customize their configuration.
 
 > [!NOTE]
@@ -56,7 +56,7 @@ The process to create an AdnGlue node is:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -218,11 +218,11 @@ Once the AdnGlue node is created, it is possible to add new inputs and remove cu
 - **Add inputs**:
     1. Select one or more mesh nodes to be assigned as inputs to the AdnGlue.
     2. Select the AdnGlue output mesh.
-    3. Press *Add Inputs* in the AdonisFX menu from the Edit Glue submenu.
+    3. Press *Add Inputs* in the Adonis menu from the Edit Glue submenu.
 - **Remove inputs**:
     1. Select one or more mesh nodes that are assigned as inputs to the AdnGlue.
     2. Select the AdnGlue output mesh.
-    3. Press *Remove Inputs* in the AdonisFX menu from the Edit Glue submenu.
+    3. Press *Remove Inputs* in the Adonis menu from the Edit Glue submenu.
     4. Alternatively, if only the AdnGlue output mesh is selected, when pressing the *Remove Inputs* button, all inputs will be removed.
 
 > [!NOTE]

--- a/docs/maya/solvers/muscle.md
+++ b/docs/maya/solvers/muscle.md
@@ -2,7 +2,7 @@
 
 AdnMuscle is a Maya deformer for fast, robust and easy-to-configure volumetric muscle simulation for digital assets. Thanks to the combination of internal (structural) and external (attachment and slide) constraints, this deformer can produce dynamics that allow the mesh to acquire the simulated characteristics of a muscle with realistic volume preservation, fibers activations to modulate the rigidity, and attachments properties to external objects to follow the global kinematics of the character.
 
-The influence these constraints have on the simulated mesh can be freely modified by painting them via the [AdonisFX Paint Tool](../tools/paint_tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the muscle's dynamics and behavior to a wide array of options.
+The influence these constraints have on the simulated mesh can be freely modified by painting them via the [Adonis Paint Tool](../tools/paint_tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the muscle's dynamics and behavior to a wide array of options.
 
 ### How To Use
 
@@ -19,7 +19,7 @@ An AdnMuscle requires the following inputs to be provided:
 To create an AdnMuscle, follow these steps:
 
 1. Select the **Targets** (if any), then the **Muscle Geometry**.
-2. Press the ![Muscle button](../../images/adn_muscle.png){style="width:4%"} button in the AdonisFX shelf or press *Muscle* in the *Solvers* submenu from the AdonisFX menu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+2. Press the ![Muscle button](../../images/adn_muscle.png){style="width:4%"} button in the Adonis shelf or press *Muscle* in the *Solvers* submenu from the Adonis menu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
 3. AdnMuscle is ready to simulate with default settings. Check the next section to customize their configuration.
 
 ## Attributes
@@ -49,7 +49,7 @@ To create an AdnMuscle, follow these steps:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -180,7 +180,7 @@ To create an AdnMuscle, follow these steps:
 
 ## Paintable Weights
 
-In order to provide more artistic control, some key parameters of the muscle solver are exposed as paintable attributes in the deformer. The [AdonisFX Paint Tool](../tools/paint_tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
+In order to provide more artistic control, some key parameters of the muscle solver are exposed as paintable attributes in the deformer. The [Adonis Paint Tool](../tools/paint_tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
 
 | Name | Default | Description |
 | :--- | :------ | :---------- |
@@ -214,7 +214,7 @@ In order to provide more artistic control, some key parameters of the muscle sol
 </figure>
 
 > [!NOTE]
-> - The attachment weights are normalized at each vertex. This normalization is applied when a stroke is finished. The use of the AdonisFX Paint Tool is mandatory for that.
+> - The attachment weights are normalized at each vertex. This normalization is applied when a stroke is finished. The use of the Adonis Paint Tool is mandatory for that.
 > - It is recommended to paint the values for the most influent attractors at the end in order to avoid the internal normalization overriding them in further strokes.
 > - Fibers and Tendon weights should only be painted on the initialization frame, being the initialization frame the lowest value between Preroll Start Time and Start Time.
 
@@ -267,11 +267,11 @@ Once the AdnMuscle deformer is created, it is possible to add and remove new tar
 - **Add targets**:
     1. Select the transform or mesh nodes (one or more) to be assigned as targets to the AdnMuscle.
     2. Select the mesh that has the AdnMuscle deformer applied.
-    3. Press the ![Add Targets button](../images/adn_add_target.png){style="width:4%"} button in the AdonisFX shelf or press *Add Targets* in the AdonisFX menu from the Edit Muscle submenu.
+    3. Press the ![Add Targets button](../images/adn_add_target.png){style="width:4%"} button in the Adonis shelf or press *Add Targets* in the Adonis menu from the Edit Muscle submenu.
 - **Remove targets**:
     1. Select one or more transform or mesh nodes that are assigned as targets to the AdnMuscle.
     2. Select the mesh that has the AdnMuscle deformer applied.
-    3. Press the ![Remove Targets button](../images/adn_remove_target.png){style="width:4%"} button in the AdonisFX shelf or press *Remove Targets* in the AdonisFX menu from the Edit Muscle submenu. 
+    3. Press the ![Remove Targets button](../images/adn_remove_target.png){style="width:4%"} button in the Adonis shelf or press *Remove Targets* in the Adonis menu from the Edit Muscle submenu. 
     4. Alternatively, if only the mesh with the AdnMuscle deformer is selected, when pressing the ![Remove Targets button](../images/adn_remove_target.png){style="width:4%"} button, all targets will be removed (transform and mesh targets).
 
 Targets can be any transformation nodes or meshes. On one hand, transformation nodes such as joints or locators are used to create attachments to their world transformation matrices. On the other hand, meshes are used to create attachments to geometry and slide on geometry constraints. Check [A Simple Setup](../simple_setup#adnmuscle) for more information on how to paint the influence maps for the mentioned constraints.
@@ -287,7 +287,7 @@ Additionally to all previously mentioned constraints, muscles can have an additi
 - **Add Segment**:
     1. Select the transform nodes from which a segment would be created for the muscle to slide on.
     2. Select the mesh that has the AdnMuscle deformer applied.
-    3. Press *Add Slide On Segment Constraint* in the AdonisFX menu from the Edit Muscle submenu.
+    3. Press *Add Slide On Segment Constraint* in the Adonis menu from the Edit Muscle submenu.
 
 > [!NOTE]
 > - The transform node selection must follow a parent to child relationship in the hierarchy (like rig joints do).
@@ -297,17 +297,17 @@ Additionally to all previously mentioned constraints, muscles can have an additi
 - **Remove Segment**: 
     1. Select one or more transform nodes that are assigned as segment anchors to the AdnMuscle.
     2. Select the mesh that has the AdnMuscle deformer applied.
-    3. Press *Remove Slide On Segment Constraint* in the AdonisFX menu from the Edit Muscle submenu. 
-    4. Alternatively, if only the mesh with the AdnMuscle deformer is selected, when pressing *Remove Slide On Segment Constraint* in the AdonisFX menu, all segments will be removed.
+    3. Press *Remove Slide On Segment Constraint* in the Adonis menu from the Edit Muscle submenu. 
+    4. Alternatively, if only the mesh with the AdnMuscle deformer is selected, when pressing *Remove Slide On Segment Constraint* in the Adonis menu, all segments will be removed.
 
 ### Rest Shape
 
-The muscle solver supports an art-directed shape to drive the fibers, shape and volume constraints. This shape is typically a sculpted version of the muscle (it must be topologically identical) that represents the muscle when it is fully activated. The artist can add and remove the custom shape from dedicated entries in the AdonisFX muscle submenu.
+The muscle solver supports an art-directed shape to drive the fibers, shape and volume constraints. This shape is typically a sculpted version of the muscle (it must be topologically identical) that represents the muscle when it is fully activated. The artist can add and remove the custom shape from dedicated entries in the Adonis muscle submenu.
 
 - **Add Rest Shape**:
     1. Select the transform or mesh node to be assigned as rest shape to the AdnMuscle.
     2. Select the mesh that has the AdnMuscle deformer applied.
-    3. Press *Add Rest Shape* in the AdonisFX menu from the Edit Muscle submenu.
+    3. Press *Add Rest Shape* in the Adonis menu from the Edit Muscle submenu.
     4. Make sure to use a *Rest Shape Weight* greater than 0.0 for this feature to take effect.
 
 > [!NOTE]
@@ -316,7 +316,7 @@ The muscle solver supports an art-directed shape to drive the fibers, shape and 
 - **Remove Rest Shape**: 
     1. Select the transform node of the rest mesh assigned to the AdnMuscle (optional).
     2. Select the mesh that has the AdnMuscle deformer applied.
-    3. Press *Remove Rest Shape* in the AdonisFX menu from the Edit Muscle submenu.
+    3. Press *Remove Rest Shape* in the Adonis menu from the Edit Muscle submenu.
     4. Alternatively, set the *Rest Shape Weight* to 0.0. The rest mesh will be ignored.
 
 On top of this, if the input activation of the muscle is also connected to the *Rest Shape Weight*, then the influence of the rest shape over the final result will be coherent with the variation of the level of activation during the simulation.
@@ -356,4 +356,4 @@ The sensors can be connected to the activation list using the [Sensors Connectio
   <figcaption><b>Figure 13</b>: Example of the Sensors Connection Editor UI listing three plug values from the activation list.</figcaption>
 </figure>
 
-The removal of input sensors connected to the activation list can be done from the AdonisFX menu in Activation > Remove Inputs option.
+The removal of input sensors connected to the activation list can be done from the Adonis menu in Activation > Remove Inputs option.

--- a/docs/maya/solvers/ribbon.md
+++ b/docs/maya/solvers/ribbon.md
@@ -2,7 +2,7 @@
 
 AdnRibbonMuscle is a Maya deformer for fast, robust and easy-to-configure muscle simulation on a surface. Thanks to the combination of internal (structural) and external (attachment and slide) constraints, this deformer can produce dynamics that allow the mesh to acquire the simulated characteristics of a ribbon with fibers activations to modulate the rigidity, and attachments to external objects to follow the global kinematics of the character.
 
-The influence these constraints have on the simulated mesh can be freely modified by painting them via the [AdonisFX Paint Tool](../tools/paint_tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the muscle's dynamics and behavior to a wide array of options.
+The influence these constraints have on the simulated mesh can be freely modified by painting them via the [Adonis Paint Tool](../tools/paint_tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the muscle's dynamics and behavior to a wide array of options.
 
 ### How To Use
 
@@ -19,7 +19,7 @@ To create an AdnRibbonMuscle deformer within a Maya scene, the following inputs 
 Follow these steps to create an AdnRibbonMuscle deformer:
 
 1. Select the **Targets** (if any) and the **Muscle Geometry** in that order.
-2. Press the ![AdnRibbonMuscle button](../../images/adn_ribbon_muscle.png){style="width:4%"} button in the AdonisFX shelf or press *Ribbon Muscle* in the *Solvers* submenu from the AdonisFX menu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+2. Press the ![AdnRibbonMuscle button](../../images/adn_ribbon_muscle.png){style="width:4%"} button in the Adonis shelf or press *Ribbon Muscle* in the *Solvers* submenu from the Adonis menu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
 3. AdnRibbonMuscle is ready to simulate with default settings. Check the next section to customize their configuration.
 
 ## Attributes
@@ -46,7 +46,7 @@ Follow these steps to create an AdnRibbonMuscle deformer:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -176,7 +176,7 @@ Follow these steps to create an AdnRibbonMuscle deformer:
 
 ## Paintable Weights
 
-In order to provide more artistic control, some key parameters of the AdnRibbonMuscle solver are exposed as paintable attributes in the deformer. The [AdonisFX Paint Tool](../tools/paint_tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
+In order to provide more artistic control, some key parameters of the AdnRibbonMuscle solver are exposed as paintable attributes in the deformer. The [Adonis Paint Tool](../tools/paint_tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
 
 | Name | Default | Description |
 | :--- | :------ | :---------- |
@@ -210,7 +210,7 @@ In order to provide more artistic control, some key parameters of the AdnRibbonM
 </figure>
 
 > [!NOTE]
-> - The attachment weights are normalized at each vertex. This normalization is applied when a stroke is finished. The use of the AdonisFX Paint Tool is mandatory for that.
+> - The attachment weights are normalized at each vertex. This normalization is applied when a stroke is finished. The use of the Adonis Paint Tool is mandatory for that.
 > - It is recommended to paint the values for the most influent attractors at the end in order to avoid the internal normalization overriding them in further strokes.
 > - Fibers and Tendon weights should only be painted on the initialization frame, being the initialization frame the lowest value between Preroll Start Time and Start Time.
 
@@ -259,11 +259,11 @@ Once the AdnRibbonMuscle deformer is created, it is possible to add and remove n
 - **Add targets**:  
     1. Select the transform or mesh nodes (one or more) to be assigned as targets to the AdnRibbonMuscle.
     2. Select the mesh that has the AdnRibbonMuscle deformer applied.
-    3. Press the ![Add Targets button](../images/adn_add_target.png){style="width:4%"} button in the AdonisFX shelf or press *Add Targets* in the AdonisFX menu from the Edit Muscle submenu.
+    3. Press the ![Add Targets button](../images/adn_add_target.png){style="width:4%"} button in the Adonis shelf or press *Add Targets* in the Adonis menu from the Edit Muscle submenu.
 - **Remove targets**:
     1. Select one or more transform or mesh nodes that are assigned as targets to the AdnRibbonMuscle.
     2. Select the mesh that has the AdnRibbonMuscle deformer applied.
-    3. Press the ![Remove Targets button](../images/adn_remove_target.png){style="width:4%"} button in the AdonisFX shelf or press *Remove Targets* in the AdonisFX menu from the Edit Muscle submenu.
+    3. Press the ![Remove Targets button](../images/adn_remove_target.png){style="width:4%"} button in the Adonis shelf or press *Remove Targets* in the Adonis menu from the Edit Muscle submenu.
     4. Alternatively, if only the mesh with the AdnRibbonMuscle deformer is selected, when pressing the ![Remove Targets button](../images/adn_remove_target.png){style="width:4%"} button, all targets will get removed (transform and mesh targets).
 
 Targets can be any transformation nodes or meshes. On one hand, transformation nodes such as joints or locators are used to create attachments to their world transformation matrices. On the other hand, meshes are used to create attachments to geometry and slide on geometry constraints. Check [A Simple Setup](../simple_setup#adnribbonmuscle) for more information on how to paint the influence maps for the mentioned constraints.
@@ -279,7 +279,7 @@ Additionally to all previously mentioned constraints, ribbon muscles can have an
 - **Add Segment**:
     1. Select the transform nodes from which a segment would be created for the muscle to slide on.
     2. Select the mesh that has the AdnRibbonMuscle deformer applied.
-    3. Press *Add Slide On Segment Constraint* in the AdonisFX menu from the *Edit* Muscle submenu.
+    3. Press *Add Slide On Segment Constraint* in the Adonis menu from the *Edit* Muscle submenu.
 
 > [!NOTE]
 > - The transform node selection must follow a parent to child relationship in the hierarchy (like rig joints do).
@@ -289,17 +289,17 @@ Additionally to all previously mentioned constraints, ribbon muscles can have an
 - **Remove Segment**:  
     1. Select one or more transform nodes that are assigned as segment anchors to the AdnRibbonMuscle.
     2. Select the mesh that has the AdnRibbonMuscle deformer applied.
-    3. Press *Remove Slide On Segment Constraint* in the AdonisFX menu from the *Edit* Muscle submenu.
-    4. Alternatively, if only the mesh with the AdnRibbonMuscle deformer is selected, when pressing *Remove Slide On Segment Constraint* in the AdonisFX menu, all segments will be removed.
+    3. Press *Remove Slide On Segment Constraint* in the Adonis menu from the *Edit* Muscle submenu.
+    4. Alternatively, if only the mesh with the AdnRibbonMuscle deformer is selected, when pressing *Remove Slide On Segment Constraint* in the Adonis menu, all segments will be removed.
 
 ### Rest Shape
 
-The muscle solver supports an art-directed shape to drive the fibers, shape and volume constraints. This shape is typically a sculpted version of the muscle (it must be topologically identical) that represents the muscle when it is fully activated. The artist can add and remove the custom shape from dedicated entries in the AdonisFX muscle submenu.
+The muscle solver supports an art-directed shape to drive the fibers, shape and volume constraints. This shape is typically a sculpted version of the muscle (it must be topologically identical) that represents the muscle when it is fully activated. The artist can add and remove the custom shape from dedicated entries in the Adonis muscle submenu.
 
 - **Add Rest Shape**:
     1. Select the transform or mesh node to be assigned as rest shape to the AdnRibbonMuscle.
     2. Select the mesh that has the AdnRibbonMuscle deformer applied.
-    3. Press *Add Rest Shape* in the AdonisFX menu from the Edit Muscle submenu.
+    3. Press *Add Rest Shape* in the Adonis menu from the Edit Muscle submenu.
 
 > [!NOTE]
 > - The topology of the rest shape and the muscle geometry must be identical (i.e. vertex count, vertex connectivity, polygonal information, etc.).
@@ -307,7 +307,7 @@ The muscle solver supports an art-directed shape to drive the fibers, shape and 
 - **Remove Rest Shape**: 
     1. Select the transform node of the rest mesh assigned to the AdnRibbonMuscle (optional).
     2. Select the mesh that has the AdnRibbonMuscle deformer applied.
-    3. Press *Remove Rest Shape* in the AdonisFX menu from the Edit Muscle submenu.
+    3. Press *Remove Rest Shape* in the Adonis menu from the Edit Muscle submenu.
 
 On top of this, if the input activation of the muscle is also connected to the *Rest Shape Weight*, then the influence of the rest shape over the final result will be coherent with the variation of the level of activation during the simulation.
 
@@ -341,4 +341,4 @@ The sensors can be connected to the activation list using the [Sensors Connectio
   <figcaption><b>Figure 11</b>: Example of the Sensors Connection Editor UI listing three plug values from the activation list.</figcaption>
 </figure>
 
-The removal of input sensors connected to the activation list can be done from the AdonisFX menu in Activation > Remove Inputs option.
+The removal of input sensors connected to the activation list can be done from the Adonis menu in Activation > Remove Inputs option.

--- a/docs/maya/solvers/simshape.md
+++ b/docs/maya/solvers/simshape.md
@@ -11,7 +11,7 @@ The AdnSimshape deformer is of great simplicity to set up and apply to a mesh wi
 To create an AdnSimshape deformer within a Maya scene, the following inputs must be provided:
 
   - **Rest Mesh (R)**: Mesh with no deformation or animation (optional).
-  - **Deform Mesh (D)**: Mesh with deformation driven by the facial expressions (optional, only if muscle activations with AdonisFX Muscle Patches is required).
+  - **Deform Mesh (D)**: Mesh with deformation driven by the facial expressions (optional, only if muscle activations with Adonis Muscle Patches is required).
   - **Animated Mesh (A)**: Mesh with deformation driven by the facial expressions and animation result of the binding to the animation rig (optional).
   - **Simulation Mesh (S)**: Mesh to apply the deformer to. This mesh can be the animation mesh or a separate mesh with no deformation nor animation.
 
@@ -24,10 +24,10 @@ To create an AdnSimshape deformer within a Maya scene, the following inputs must
 When initially creating an AdnSimshape deformer, it is possible to add both a **Simulated Mesh** and a **Rest Mesh**, or only add a **Simulated Mesh**. The process to create an AdnSimshape deformer is:
 
   1. Select the **Rest Mesh** (optional), then the **Simulated Mesh**.
-  2. Press the ![Simshape button](../../images/adn_simshape.png){style="width:4%"} in the AdonisFX shelf or press *Simshape* in AdonisFX menu under the *Create* section. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+  2. Press the ![Simshape button](../../images/adn_simshape.png){style="width:4%"} in the Adonis shelf or press *Simshape* in Adonis menu under the *Create* section. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
   3. A message in the terminal will notify that AdnSimshape has been created properly, meaning that it is ready to simulate with default settings and *Material* set to *Skin*. Check the next section to customize their configuration.
 
-In order to add or remove any of the optional meshes, a set of menu items are exposed in AdonisFX menu > Edit Simshape:
+In order to add or remove any of the optional meshes, a set of menu items are exposed in Adonis menu > Edit Simshape:
 
   - Add Rest Mesh
   - Remove Rest Mesh
@@ -39,13 +39,13 @@ In order to add or remove any of the optional meshes, a set of menu items are ex
 To add any of these meshes to AdnSimshape, follow a similar procedure to when first creating the deformer:
 
   1. First, select the **Additional Mesh**. then the **Simulated Mesh**.
-  2. Press the corresponding menu element in AdonisFX menu > Edit Simshape.
+  2. Press the corresponding menu element in Adonis menu > Edit Simshape.
   3. A message in the terminal will notify that the action has been successful.
 
 To remove any of these meshes from AdnSimshape follow this procedure:
 
   1. Select only the mesh with AdnSimshape applied.
-  2. Press the corresponding menu element in AdonisFX menu > Edit Simshape.
+  2. Press the corresponding menu element in Adonis menu > Edit Simshape.
   3. A message in the terminal will notify that the action has been successful.
 
 ## Attributes
@@ -62,8 +62,8 @@ To remove any of these meshes from AdnSimshape follow this procedure:
 ### Muscles Activation Settings
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
-| **Activation Mode**          | Enumerator | No activation | ✗ | Mode to drive the muscle activations. There are 3 different modes: <ul><li>Muscle Patches (Disabled by default): An AdonisFX Muscle Patches file (`.amp`) has to be provided to enable this option.</li><li>Plug Values (Disabled by default): The attribute values ActivationList.Activation should be populated to enable this option. The activation data will be read from the plug values.</li><li>No Activation (Enabled by default): No activation is read.</li></ul> |
-| **Muscle Patches File**      | String     |               | ✗ | Path to the AdonisFX Muscle Patches file (`.amp`). |
+| **Activation Mode**          | Enumerator | No activation | ✗ | Mode to drive the muscle activations. There are 3 different modes: <ul><li>Muscle Patches (Disabled by default): An Adonis Muscle Patches file (`.amp`) has to be provided to enable this option.</li><li>Plug Values (Disabled by default): The attribute values ActivationList.Activation should be populated to enable this option. The activation data will be read from the plug values.</li><li>No Activation (Enabled by default): No activation is read.</li></ul> |
+| **Muscle Patches File**      | String     |               | ✗ | Path to the Adonis Muscle Patches file (`.amp`). |
 | **Activation Smoothing**     | Integer    | 1             | ✗ | Number of iterations for the activation smoothing algorithm. The greater the number, the smoother the activations per patch will be. Has a range of \[1, 20\]. The upper limit is soft, higher values can be used. |
 | **Bidirectional Activation** | Boolean    | False         | ✓ | Flag to enable muscle activations in the positive and negative directions of the muscle patches fibers. |
 | **Write Out Activation**     | Boolean    | False         | ✓ | Flag to toggle the writing of activations into an output plug. |
@@ -79,7 +79,7 @@ To remove any of these meshes from AdnSimshape follow this procedure:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -230,7 +230,7 @@ To better visualize deformer constraints and attributes in the Maya viewport the
 To enable the debugger the *Debug* checkbox must be marked. To select the specific feature to visualize, choose it from the list provided in *Features*. The features that can be visualized with the debugger in the AdnSimshape deformer are:
 
  - **Distance Constraints**: For each pair of vertices forming a constraint a line will be drawn. If the *Triangulate Mesh* option is disabled the debugged lines will align with the edges of the mesh polygons. If the *Triangulate Mesh* option is enabled the debugged lines will align with the edges of the underlying triangulation of the mesh.
- - **Muscle Fibers**: For each vertex, a line will be drawn showing the direction of the muscle fibers. The debug lines will only be displayed in case muscle activations have been enabled with an AdonisFX Muscle Patches file.
+ - **Muscle Fibers**: For each vertex, a line will be drawn showing the direction of the muscle fibers. The debug lines will only be displayed in case muscle activations have been enabled with an Adonis Muscle Patches file.
  - **Shape Preservation**: For each vertex with a shape preservation weight greater than 0.0, a line will be drawn from each adjacent vertex to the opposite adjacent vertex.
  - **Slide Collision Constraints**: For each vertex, a line will be drawn from the mesh to the closest point of a collider. The debug lines will only be displayed in case collisions are enabled and colliders have been set up.
  - **Sliding Surface On Collider**: For each vertex, lines will outline the collider triangles within the reach of its *Max Sliding Distance*
@@ -264,8 +264,8 @@ AdnSimshape can emulate the behavior of facial muscles by computing the muscle a
 
 > [!NOTE = Activation Modes]
 > === Muscle Patches
-> The data in the AdonisFX Muscle Patches file in combination with the deformation status of the Deform Mesh are used to calculate the amount of activation at each vertex. The AMP file is the result of a Machine Learning process and can be generated following the steps presented in the next section. The requirements for this mode to work are:
->  - AdonisFX Muscle Patches file
+> The data in the Adonis Muscle Patches file in combination with the deformation status of the Deform Mesh are used to calculate the amount of activation at each vertex. The AMP file is the result of a Machine Learning process and can be generated following the steps presented in the next section. The requirements for this mode to work are:
+>  - Adonis Muscle Patches file
 >  - Deform mesh
 >
 >  === Plug Values
@@ -294,7 +294,7 @@ The Learn Muscle Patches tool allows the user to generate the AMP file:
   <figcaption><b>Figure 9</b>: Learn Muscle Patches UI.</figcaption>
 </figure>
 
-1. Open the **Learn Muscle Patches UI**. Using the shelf button ![Learn Muscle Patches icon](../../images/adn_learn_muscle_patches.png){style="width:4%"} or go to the Edit Simshape submenu from the AdonisFX menu and press *Learn Muscle Patches UI*.
+1. Open the **Learn Muscle Patches UI**. Using the shelf button ![Learn Muscle Patches icon](../../images/adn_learn_muscle_patches.png){style="width:4%"} or go to the Edit Simshape submenu from the Adonis menu and press *Learn Muscle Patches UI*.
 2. Add the neutral mesh.
 3. Add the target meshes. These geometries are the set of facial expressions produced by blendshapes or a facial rig.
 4. Select the vertices on the neutral mesh that will be involved in the training for the muscle patches generation. If *Add Selected* is pressed with no selection, the tool will display a pop-up and inform that all vertices will be used for the learning process. This button has to necessarily be pressed to enable the execution of the learning process.
@@ -331,7 +331,7 @@ In order to toggle and untoggle the debug mode, follow these steps:
 
 1. Stop the simulation.
 2. Move to pre-roll time or start time.
-3. Press ![Simshape debug icon](../images/adn_simshape_debugger.png){style="width:4%"} or go to the Edit Simshape submenu from the AdonisFX menu and press *Activations Debugger*.
+3. Press ![Simshape debug icon](../images/adn_simshape_debugger.png){style="width:4%"} or go to the Edit Simshape submenu from the Adonis menu and press *Activations Debugger*.
 
 > [!NOTE]
 > - The active status of the debugger is evaluated at initialization only.
@@ -346,7 +346,7 @@ AdnSimshape supports an internal collider that has to be bound to the rig and co
 
 1. Select the collider object.
 2. Select the mesh with the AdnSimshape deformer.
-3. Press the AdonisFX Shelf > *Add Collider* Shelf Button ![Add collider icon](../images/adn_add_collider.png){style="width:4%"} or go to the Edit Simshape submenu from the AdonisFX menu and press *Add Collider*.
+3. Press the Adonis Shelf > *Add Collider* Shelf Button ![Add collider icon](../images/adn_add_collider.png){style="width:4%"} or go to the Edit Simshape submenu from the Adonis menu and press *Add Collider*.
 
 > [!NOTE]
 > - Avoid intersections between the collider and the rest/simulated mesh.
@@ -356,7 +356,7 @@ AdnSimshape supports an internal collider that has to be bound to the rig and co
 
 1. Select the collider object.
 2. Select the mesh with the AdnSimshape deformer.
-3. Press the AdonisFX Shelf > *Remove Collider* Shelf Button ![Remove collider icon](../images/adn_remove_collider.png){style="width:4%"} or go to the Edit Simshape submenu from the AdonisFX menu and press *Remove Collider*.
+3. Press the Adonis Shelf > *Remove Collider* Shelf Button ![Remove collider icon](../images/adn_remove_collider.png){style="width:4%"} or go to the Edit Simshape submenu from the Adonis menu and press *Remove Collider*.
 
 #### Add Rest Collider
 
@@ -364,7 +364,7 @@ The use of rest collider is recommended when the pre-roll simulation is not comp
 
 1. Select the rest collider object.
 2. Select the mesh with the AdnSimshape deformer.
-3. Go to the Edit Simshape submenu from the AdonisFX menu and press *Add Rest Collider*.
+3. Go to the Edit Simshape submenu from the Adonis menu and press *Add Rest Collider*.
 
 > [!NOTE]
 > - Avoid intersections between the collider and the rest mesh.
@@ -375,4 +375,4 @@ The use of rest collider is recommended when the pre-roll simulation is not comp
 
 1. Select the rest collider object.
 2. Select the mesh with the AdnSimshape deformer.
-3. Go to the Edit Simshape submenu from the AdonisFX menu and press *Remove Rest Collider*.
+3. Go to the Edit Simshape submenu from the Adonis menu and press *Remove Rest Collider*.

--- a/docs/maya/solvers/skin.md
+++ b/docs/maya/solvers/skin.md
@@ -2,7 +2,7 @@
 
 AdnSkin is a Maya deformer for fast, robust and easy-to-configure skin simulation for digital assets. Thanks to the combination of internal and external constraints, the deformer can produce dynamics that allow the skin mesh to realistically react to the deformations of internal tissues (e.g. muscles, fascia) over time.
 
-The influence these constraints have on the simulated mesh can be freely modified by painting them via the [AdonisFX Paint Tool](../tools/paint_tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the skin's dynamics and behavior to a wide array of options.
+The influence these constraints have on the simulated mesh can be freely modified by painting them via the [Adonis Paint Tool](../tools/paint_tool) or by uniformly regulating their influence via multipliers in the Attribute Editor. Besides the maps and multipliers there are many other parameters to regulate the skin's dynamics and behavior to a wide array of options.
 
 ### How To Use
 
@@ -19,7 +19,7 @@ To create an AdnSkin deformer within a Maya scene, the following inputs must be 
 The process to create an AdnSkin deformer is:
 
 1. Select the **Targets** (optional, they can be added later), then the **Skin Mesh**.
-2. Press ![Skin button](../../images/adn_skin.png){style="width:4%"} in the AdonisFX shelf or *Skin* in the AdonisFX menu, under the *Create* section. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+2. Press ![Skin button](../../images/adn_skin.png){style="width:4%"} in the Adonis shelf or *Skin* in the Adonis menu, under the *Create* section. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
 3. A message in the terminal will notify you that AdnSkin has been created properly, meaning that it is ready to simulate with default settings. Check the next section to customize their configuration.
 
 ## Attributes
@@ -44,7 +44,7 @@ The process to create an AdnSkin deformer is:
 | Name | Type | Default | Animatable | Description |
 | :--- | :--- | :------ | :--------- | :---------- |
 | **Time Scale**       | Float      | 1.0             | ✓ | Sets the scaling factor applied to the simulation time step. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
-| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). AdonisFX interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
+| **Space Scale**      | Float      | 1.0             | ✓ | Sets the scaling factor applied to the masses and/or the forces (e.g. gravity). Adonis interprets the scene units in centimeters. If modeling your creature you apply a scaling factor for whatever reason (e.g. to avoid precision issues in Maya), you will have to adjust for this scaling factor using this attribute. If your character is supposed to be 170 units tall, but you prefer to model it to be 17 units tall, then you will need to set the space scale to a value of 10. This will ensure that your 17 units creature will simulate as if it was 170 units tall. Has a range of \[0.0, 2.0\]. The upper limit is soft, higher values can be used. |
 | **Space Scale Mode** | Enumerator | Masses + Forces | ✓ | Determines if the spatial scaling affects the masses, the forces, or both. The available options are: <ul><li>Masses: The *Space Scale* only affects masses.</li><li>Forces: The *Space Scale* only affects forces.</li><li>Masses + Forces: The *Space Scale* affects masses and forces.</li></ul> |
 
 ### Gravity
@@ -175,7 +175,7 @@ The process to create an AdnSkin deformer is:
 
 ## Paintable Weights
 
-In order to provide more artistic control, some key parameters of the AdnSkin solver are exposed as paintable attributes in the deformer. The [AdonisFX Paint Tool](../tools/paint_tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
+In order to provide more artistic control, some key parameters of the AdnSkin solver are exposed as paintable attributes in the deformer. The [Adonis Paint Tool](../tools/paint_tool) must be used to paint those parameters to ensure that the values satisfy the solver requirements.
 
 | Name | Default | Description |
 | :--- | :------ | :---------- |
@@ -251,9 +251,9 @@ Once the AdnSkin deformer is created, it is possible to add and remove new targe
 - **Add targets**:
     1. Select one or more mesh nodes to be assigned as targets to the AdnSkin.
     2. Select the mesh that has the AdnSkin deformer applied.
-    3. Press the ![Add Targets](../images/adn_add_skin_targets.png){style="width:4%"} button in the AdonisFX shelf or press *Add Targets* in the AdonisFX menu from the Edit Skin submenu.
+    3. Press the ![Add Targets](../images/adn_add_skin_targets.png){style="width:4%"} button in the Adonis shelf or press *Add Targets* in the Adonis menu from the Edit Skin submenu.
 - **Remove targets**:
     1. Select one or more mesh nodes that are assigned as targets to the AdnSkin.
     2. Select the mesh that has the AdnSkin deformer applied.
-    3. Press the ![Remove Targets](../images/adn_remove_skin_targets.png){style="width:4%"} button in the AdonisFX shelf or press *Remove Targets* in the AdonisFX menu from the Edit Skin submenu.
+    3. Press the ![Remove Targets](../images/adn_remove_skin_targets.png){style="width:4%"} button in the Adonis shelf or press *Remove Targets* in the Adonis menu from the Edit Skin submenu.
     4. Alternatively, if only the mesh with the AdnSkin deformer is selected, when pressing the ![Remove Targets](../images/adn_remove_skin_targets.png){style="width:4%"} button, all targets will be removed.

--- a/docs/maya/tools/exporter.md
+++ b/docs/maya/tools/exporter.md
@@ -1,12 +1,12 @@
 # Export
 
-The AdonisFX Export is a tool designed to facilitate the export of a complete AdonisFX rig from a Maya scene. This tool enables users to selectively export various components of an AdonisFX rig, ensuring a structured and efficient workflow for data transfer, backup, or reuse across different projects.
+The Adonis Export is a tool designed to facilitate the export of a complete Adonis rig from a Maya scene. This tool enables users to selectively export various components of an Adonis rig, ensuring a structured and efficient workflow for data transfer, backup, or reuse across different projects.
 
 ## UI
 
 <figure style="width:50%;" markdown>
-  ![AdonisFX Export Tool](../images/exporter_ui.png)
-  <figcaption><b>Figure 1</b>: AdonisFX Export UI. </figcaption>
+  ![Adonis Export Tool](../images/exporter_ui.png)
+  <figcaption><b>Figure 1</b>: Adonis Export UI. </figcaption>
 </figure>
 
 The Export Tool offers an intuitive interface (see Figure 1), allowing users to configure export settings according to their specific requirements. Below is a breakdown of the available UI elements:​
@@ -26,7 +26,7 @@ The Export Tool offers an intuitive interface (see Figure 1), allowing users to 
     - Push: include AdnPush nodes in the exported data.
 
 - **Utils**: Allows exporting additional utility components from the setup. Options include:
-    - Sensors & Locators: include AdonisFX sensors and locators in the exported data, ensuring proper connections between components.
+    - Sensors & Locators: include Adonis sensors and locators in the exported data, ensuring proper connections between components.
     - Activation: include activation nodes and their existing connections to AdnMuscle nodes in the exported data.
     - Remap: include AdnRemap nodes in the exported data.
     - Edge Evaluator: include AdnEdgeEvaluator nodes in the exported data.
@@ -38,14 +38,14 @@ The Export Tool offers an intuitive interface (see Figure 1), allowing users to 
 
 ## How To Use
 
-Open the scene of a fully configured AdonisFX rig (see Figure 2) and follow these steps:
+Open the scene of a fully configured Adonis rig (see Figure 2) and follow these steps:
 
 <figure markdown>
-  ![AdonisFX Export Tool](../images/exporter_scene.png)
+  ![Adonis Export Tool](../images/exporter_scene.png)
   <figcaption><b>Figure 2</b>: Fully configured rig of a biped character. The rig includes sensors, locators, activation nodes, muscles, glue, fascia, fat, skin, skin merge, and relax.</figcaption>
 </figure>
 
-1. Go to *AdonisFX menu > I/O > Export (beta)* to open the *Export* window.
+1. Go to *Adonis menu > I/O > Export (beta)* to open the *Export* window.
 
 2. Specify the file path where the exported data will be saved (e.g., `path/to/the/file.json`).
 
@@ -56,7 +56,7 @@ Open the scene of a fully configured AdonisFX rig (see Figure 2) and follow thes
 Depending on the complexity of the rig, the export process might take a few seconds to complete. Once finished, a JSON file containing the exported data will be created in the specified path.
 
 <figure markdown>
-  ![AdonisFX Export Tool](../../images/exported_file.png)
+  ![Adonis Export Tool](../../images/exported_file.png)
   <figcaption><b>Figure 3</b>: Example of the generated JSON file after exporting.</figcaption>
 </figure>
 

--- a/docs/maya/tools/importer.md
+++ b/docs/maya/tools/importer.md
@@ -1,12 +1,12 @@
 # Import
 
-The AdonisFX Import is a tool designed to facilitate the import of a complete AdonisFX rig into a Maya scene. This tool enables users to restore previously exported rigs by reading the data from a JSON file and rebuilding all selected components in the scene. The tool ensures a structured and efficient workflow for transferring, reusing, or backing up AdonisFX rigs.
+The Adonis Import is a tool designed to facilitate the import of a complete Adonis rig into a Maya scene. This tool enables users to restore previously exported rigs by reading the data from a JSON file and rebuilding all selected components in the scene. The tool ensures a structured and efficient workflow for transferring, reusing, or backing up Adonis rigs.
 
 ## UI
 
 <figure style="width:50%;" markdown>
-  ![AdonisFX Import Tool](../images/importer_ui.png)
-  <figcaption><b>Figure 1</b>: AdonisFX Import UI.</figcaption>
+  ![Adonis Import Tool](../images/importer_ui.png)
+  <figcaption><b>Figure 1</b>: Adonis Import UI.</figcaption>
 </figure>
 
 The Import Tool offers an intuitive interface (see Figure 1), allowing users to configure import settings according to their specific requirements. Below is a breakdown of the available UI elements:
@@ -26,7 +26,7 @@ The Import Tool offers an intuitive interface (see Figure 1), allowing users to 
     - Push: imports AdnPush nodes and their settings.
 
 - **Utils**: Allows importing utility components from the JSON file. Options include:
-    - Sensors & Locators: imports AdonisFX sensors and locators, ensuring proper connections between components.
+    - Sensors & Locators: imports Adonis sensors and locators, ensuring proper connections between components.
     - Activation: imports activation nodes and their connections to AdnMuscle nodes.
     - Remap: imports AdnRemap nodes, including their settings and connections to other nodes.
     - Edge Evaluator: imports EdgeEvaluator nodes, including their settings and connections to other nodes.
@@ -38,30 +38,30 @@ The Import Tool offers an intuitive interface (see Figure 1), allowing users to 
 
 ## Requirements
 
-Before importing an AdonisFX rig, the target Maya scene must meet the following requirements to ensure a successful reconstruction:
+Before importing an Adonis rig, the target Maya scene must meet the following requirements to ensure a successful reconstruction:
 
 - Matching Geometry for *Solvers* and *Deformers*: Any geometry that had solvers or deformers applied in the original scene must also exist in the target scene. The geometries must have the same name and topology (i.e. same vertex count and vertex IDs) as in the exported scene to ensure that weight maps and settings are correctly restored.
 
-- Matching Transforms for *Locators* and *Sensors*: Since AdonisFX locators and sensors rely on transform inputs, the target scene must contain transforms with the same names as those used in the exported rig. This ensures that connections between nodes are restored properly.
+- Matching Transforms for *Locators* and *Sensors*: Since Adonis locators and sensors rely on transform inputs, the target scene must contain transforms with the same names as those used in the exported rig. This ensures that connections between nodes are restored properly.
 
 ## How To Use
 
-To import an AdonisFX rig, ensure that you have a valid exported JSON file and follow these steps:
+To import an Adonis rig, ensure that you have a valid exported JSON file and follow these steps:
 
-1. Optionally, if the target scene contains any dirty or unwanted AdonisFX nodes, it may be advisable to remove all of them by using the *Clear* option provided in *AdonisFX menu > Tools > Utils > Clear*.
+1. Optionally, if the target scene contains any dirty or unwanted Adonis nodes, it may be advisable to remove all of them by using the *Clear* option provided in *Adonis menu > Tools > Utils > Clear*.
 
 <figure markdown>
   ![Biped scene before importing](../images/importer_scene_00.png)
   <figcaption><b>Figure 2</b>: Scene of a biped character after executing the Clear and ready to import.</figcaption>
 </figure>
 
-2. Go to *AdonisFX menu > I/O > Import (beta)* to open the *Import* window.
+2. Go to *Adonis menu > I/O > Import (beta)* to open the *Import* window.
 
 3. Specify the file path of the JSON file that contains the exported rig data.
 
 <figure markdown>
   ![Select JSON file](../../images/importer_file.png)
-  <figcaption><b>Figure 3</b>: File exported from an AdonisFX rig.</figcaption>
+  <figcaption><b>Figure 3</b>: File exported from an Adonis rig.</figcaption>
 </figure>
 
 4. Select the features to import from the *Solvers*, *Deformers* and *Utils* sections. To import the entire rig, enable all options.
@@ -72,7 +72,7 @@ Depending on the complexity of the rig, the import process might take a few seco
 
 <figure markdown>
   ![Select JSON file](../images/importer_scene_01.png)
-  <figcaption><b>Figure 4</b>: Scene after importing the rig from a JSON file. All AdonisFX nodes are created and configured. Some of them are visible in the outliner as well as the locators are rendered in the viewport.</figcaption>
+  <figcaption><b>Figure 4</b>: Scene after importing the rig from a JSON file. All Adonis nodes are created and configured. Some of them are visible in the outliner as well as the locators are rendered in the viewport.</figcaption>
 </figure>
 
 The previous steps corresponds to importing a rig that was exported from the same scene. However the same steps can be followed to transfer the exported rig to a different asset as long as the target scene fulfills the requirements listed in this [section](#requirements).

--- a/docs/maya/tools/mirror_tool.md
+++ b/docs/maya/tools/mirror_tool.md
@@ -1,19 +1,19 @@
 # Mirror Tool
 
-The **AdonisFX Mirror Tool** is a feature designed to simplify and speed up the muscle setup process for digital characters within Maya. This tool efficiently transfers muscle configurations from one side of a character to the other, based on consistent naming conventions to distinguish between left and right sides. By automating this process, it significantly reduces the time and effort required to replicate complex muscle setups, enhancing efficiency and consistency.​
+The **Adonis Mirror Tool** is a feature designed to simplify and speed up the muscle setup process for digital characters within Maya. This tool efficiently transfers muscle configurations from one side of a character to the other, based on consistent naming conventions to distinguish between left and right sides. By automating this process, it significantly reduces the time and effort required to replicate complex muscle setups, enhancing efficiency and consistency.​
 
 The tool replicates the following components:​
 
 - **AdnMuscle deformers**, including their configurations, paintable maps, geometry targets, and connections to locators.​
-- The three types of **AdonisFX locators** (i.e. AdnLocatorPosition, AdnLocatorDistance, and AdnLocatorRotation).
-- The three types of **AdonisFX sensors** (i.e. AdnSensorPosition, AdnSensorDistance, and AdnSensorRotation).
+- The three types of **Adonis locators** (i.e. AdnLocatorPosition, AdnLocatorDistance, and AdnLocatorRotation).
+- The three types of **Adonis sensors** (i.e. AdnSensorPosition, AdnSensorDistance, and AdnSensorRotation).
 - **AdnActivation nodes**, including their input and output connections.
 
 ## UI
 
 <figure markdown>
-  ![AdonisFX Mirror Tool](../images/mirror_tool.png) 
-  <figcaption><b>Figure 1</b>: AdonisFX Mirror Tool UI. </figcaption>
+  ![Adonis Mirror Tool](../images/mirror_tool.png) 
+  <figcaption><b>Figure 1</b>: Adonis Mirror Tool UI. </figcaption>
 </figure>
 
 The Mirror Tool window is designed to be simple and intuitive, it contains the following elements:
@@ -63,14 +63,14 @@ In order to use the **Mirror Tool**, the rig must meet the following requirement
 
 2. Select all geometries from the source side that have an AdnMuscle deformer applied and need to be mirrored.
 
-3. Add to the selection all the AdonisFX locators from the same source side that need to be mirrored. Note that sensors and activation nodes (as not being DAG objects) do not need to be added to the selection. The Mirror Tool will automatically handle their mirroring.
+3. Add to the selection all the Adonis locators from the same source side that need to be mirrored. Note that sensors and activation nodes (as not being DAG objects) do not need to be added to the selection. The Mirror Tool will automatically handle their mirroring.
 
 <figure style="width:90%; margin-left:5%" markdown>
   ![Mirror Script Selection](../images/mirror_tool_02.png)
   <figcaption><b>Figure 4</b>: All geometry muscles and locators on the left side selected.</figcaption>
 </figure>
 
-4. Go to *AdonisFX Menu > Tools > Mirror* to open the Mirror Tool window (see Figure 1). Provide the naming-related settings (*Mirror by*, *Left* and *Right*) that the rig follows and click *Accept* or *Apply* to start the mirroring process.
+4. Go to *Adonis Menu > Tools > Mirror* to open the Mirror Tool window (see Figure 1). Provide the naming-related settings (*Mirror by*, *Left* and *Right*) that the rig follows and click *Accept* or *Apply* to start the mirroring process.
 
 5. If the selection does not contain muscle geometries or locators, dedicated dialogs (Figure 5 and 6 respectively) will be displayed informing about what is missing in the selection and asking for confirmation to continue. Also, if there are no muscle geometries nor locators found in the selection, then another dialog is displayed informing that the tool can't proceed with the mirroring (Figure 7).
 

--- a/docs/maya/tools/paint_tool.md
+++ b/docs/maya/tools/paint_tool.md
@@ -1,33 +1,33 @@
 # Paint Tool
 
-The **AdonisFX Paint Tool** is meant to be used for the manipulation of the paintable attributes of the AdnSkin, AdnMuscle and AdnRibbonMuscle deformers. Its functionalities are very similar to the standard Maya paint tool functionalities plus the ability to paint attributes with multiple influences (e.g. attachment to transform constraints) where a single vertex can adopt a different weight value for the same attribute driven by multiple influent external objects. Also, it ensures the normalization of dependent attributes like hard, soft and slide constraints in AdnSkin deformer.
+The **Adonis Paint Tool** is meant to be used for the manipulation of the paintable attributes of the AdnSkin, AdnMuscle and AdnRibbonMuscle deformers. Its functionalities are very similar to the standard Maya paint tool functionalities plus the ability to paint attributes with multiple influences (e.g. attachment to transform constraints) where a single vertex can adopt a different weight value for the same attribute driven by multiple influent external objects. Also, it ensures the normalization of dependent attributes like hard, soft and slide constraints in AdnSkin deformer.
 
 <figure markdown>
-  ![AdonisFX Paint Tool](../images/tools_paint_tool.png)
-  <figcaption><b>Figure 1</b>: AdonisFX Paint Tool.</figcaption>
+  ![Adonis Paint Tool](../images/tools_paint_tool.png)
+  <figcaption><b>Figure 1</b>: Adonis Paint Tool.</figcaption>
 </figure>
 
-The use of this tool is required for the correct setup of skin, muscle and ribbon muscle solvers. After every stroke, the internal logic processes the painted map and updates all dependent maps to keep the configuration of the solver safe. For example, if the influence of one target of an AdnMuscle which has two targets assigned is painted, then the tool will update the weights of the other target to ensure that the addition of both is normalized at each vertex (the normalization process is independent for transform and geometry targets). The same applies if hard constraints of an AdnSkin deformer are painted: the soft and slide constraints maps will be updated internally to keep the addition of the three maps normalized. Thanks to this logic, switching attributes (see Figure 2 and Figure 3) or selecting influences (see Figure 4) from the AdonisFX Paint Tool provides automatic feedback to the user of the current status of all the maps.
+The use of this tool is required for the correct setup of skin, muscle and ribbon muscle solvers. After every stroke, the internal logic processes the painted map and updates all dependent maps to keep the configuration of the solver safe. For example, if the influence of one target of an AdnMuscle which has two targets assigned is painted, then the tool will update the weights of the other target to ensure that the addition of both is normalized at each vertex (the normalization process is independent for transform and geometry targets). The same applies if hard constraints of an AdnSkin deformer are painted: the soft and slide constraints maps will be updated internally to keep the addition of the three maps normalized. Thanks to this logic, switching attributes (see Figure 2 and Figure 3) or selecting influences (see Figure 4) from the Adonis Paint Tool provides automatic feedback to the user of the current status of all the maps.
 
 > [!NOTE]
 > AdnSimshape and AdnSkinMerge do not require this tool. Their paintable maps can be manipulated through the standard Maya paint context.
 
 To open the tool:
 
-  1. Select the mesh with the AdonisFX deformer applied to.
-  2. Press the paint tool ![paint tool](../images/adn_paint_tool.png){style="width:4%"} shelf button or go to AdonisFX Menu > *Paint Tool*.
+  1. Select the mesh with the Adonis deformer applied to.
+  2. Press the paint tool ![paint tool](../images/adn_paint_tool.png){style="width:4%"} shelf button or go to Adonis Menu > *Paint Tool*.
 
 > [!NOTE]
 > - The paint context is configured from the given selection to allow painting.
 > - Make sure to select the transform node of the mesh.
-> - If the context does not allow painting, it is probably because the selected node is not a transform mesh node with an AdonisFx paintable deformer. Please, select the transform mesh node and click *Refresh From Selection* or restart the AdonisFX Paint Tool.
+> - If the context does not allow painting, it is probably because the selected node is not a transform mesh node with an Adonis paintable deformer. Please, select the transform mesh node and click *Refresh From Selection* or restart the Adonis Paint Tool.
 
-If the selection provided is valid, meaning the selected mesh has one of the AdonisFX deformers listed before, then the paint context will get configured and the user can paint. The map to be painted is the one associated with the selected attribute in the enumerator exposed at the top of the UI.
+If the selection provided is valid, meaning the selected mesh has one of the Adonis deformers listed before, then the paint context will get configured and the user can paint. The map to be painted is the one associated with the selected attribute in the enumerator exposed at the top of the UI.
 
 > [!NOTE]
-> - With the optimizations introduced to the AdonisFX Paint Tool in version 1.4.0, the AdnWeightsDisplayNode is deprecated and no longer needed.
+> - With the optimizations introduced to the Adonis Paint Tool in version 1.4.0, the AdnWeightsDisplayNode is deprecated and no longer needed.
 > - This deprecation is fully backward-compatible, meaning that scenes created in earlier versions will continue to work seamlessly in version 1.4.0.
-> - In addition, we recommend using the utility available under AdonisFX Menu > Utils > *Upgrade Deprecated Nodes*, which safely removes any instances of the AdnWeightsDisplayNode from your scenes.
+> - In addition, we recommend using the utility available under Adonis Menu > Utils > *Upgrade Deprecated Nodes*, which safely removes any instances of the AdnWeightsDisplayNode from your scenes.
 
 Depending on the deformer and the attribute selected the UI can adjust to support multi-influence attributes by exposing the influences or restricting certain functionalities of the tool. In the following sections, the specific behavior of the tool for each deformer is presented.
 
@@ -37,12 +37,12 @@ In the specific case of muscle deformers, the tool will display the following at
 
 <figure markdown>
   ![Paint Tool Muscle Attributes example (Part 1)](../images/tools_paint_tool_muscle_attributes_00.png) 
-  <figcaption><b>Figure 2</b>: Paintable attributes in AdonisFX muscle deformer (Part 1). </figcaption>
+  <figcaption><b>Figure 2</b>: Paintable attributes in Adonis muscle deformer (Part 1). </figcaption>
 </figure>
 
 <figure markdown>
   ![Paint Tool Muscle Attributes example (Part 2)](../images/tools_paint_tool_muscle_attributes_01.png) 
-  <figcaption><b>Figure 3</b>: Paintable attributes in AdonisFX muscle deformer (Part 2). </figcaption>
+  <figcaption><b>Figure 3</b>: Paintable attributes in Adonis muscle deformer (Part 2). </figcaption>
 </figure>
 
   - **Attachments To Geometry** and **Attachments To Transform**
@@ -53,8 +53,8 @@ In the specific case of muscle deformers, the tool will display the following at
     - If any target is removed or added to the system, then the paint tool will refresh the list on mouse hover over the UI.
 
     <figure markdown>
-      ![AdonisFX Paint Tool attachments attribute](../images/tools_paint_tool_attachment_attribute.png)
-      <figcaption><b>Figure 4</b>: AdonisFX Paint Tool listing multiple transform attachments.</figcaption>
+      ![Adonis Paint Tool attachments attribute](../images/tools_paint_tool_attachment_attribute.png)
+      <figcaption><b>Figure 4</b>: Adonis Paint Tool listing multiple transform attachments.</figcaption>
     </figure>
 
   - **Compression Resistance** and **Stretching Resistance**
@@ -90,8 +90,8 @@ In the specific case of muscle deformers, the tool will display the following at
     - If more than one segment was added to the system, then the paint tool will normalize the weights automatically after a stroke has been completed, meaning that the addition of all slide on segment constraint weights in a vertex will always add up to a maximum value of 1.0.
 
     <figure markdown>
-      ![AdonisFX Paint Tool slide on segment influences](../images/tools_paint_tool_sos_attribute.png)
-      <figcaption><b>Figure 5</b>: AdonisFX Paint Tool listing multiple segments.</figcaption>
+      ![Adonis Paint Tool slide on segment influences](../images/tools_paint_tool_sos_attribute.png)
+      <figcaption><b>Figure 5</b>: Adonis Paint Tool listing multiple segments.</figcaption>
     </figure>
 
   - **Sliding Distance Multiplier**
@@ -159,7 +159,7 @@ In the specific case of an AdnSkin deformer, the tool will display the following
 
 ### Paint Tool Visualization Modes
 
-The AdonisFX Paint Tool provides two visualization modes in the *Visualization* UI group. The available options are *Greyscale* and *Heat Map*.
+The Adonis Paint Tool provides two visualization modes in the *Visualization* UI group. The available options are *Greyscale* and *Heat Map*.
 
 The *Greyscale* mode colors vertices from black to white based on the painted weight (black for 0.0 and white for 1.0). This is the default mode and provides a visualization similar to the Maya Paint Tool.
 

--- a/docs/maya/tools/sensors_connection_editor.md
+++ b/docs/maya/tools/sensors_connection_editor.md
@@ -1,8 +1,8 @@
 # Sensors Connection Editor
 
-To ease the connection of the sensors to the muscle activations AdonisFX provides the **Sensors Connection Editor** tool. Instead of connecting the sensors directly to the muscle deformers, this tool is designed to make the connection through the locators in order to keep the node graph aligned with the standard structure in AdonisFX of: (1) sensors connected to locators, (2) then locators connected to muscles.
+To ease the connection of the sensors to the muscle activations Adonis provides the **Sensors Connection Editor** tool. Instead of connecting the sensors directly to the muscle deformers, this tool is designed to make the connection through the locators in order to keep the node graph aligned with the standard structure in Adonis of: (1) sensors connected to locators, (2) then locators connected to muscles.
 
-To use this tool go to the AdonisFX Menu > Sensors (under the Edit section) > *Connection Editor*.
+To use this tool go to the Adonis Menu > Sensors (under the Edit section) > *Connection Editor*.
 
 <figure markdown> 
   ![Connection Editor](../images/tools_sensors_connection_editor_empty.png) 
@@ -11,7 +11,7 @@ To use this tool go to the AdonisFX Menu > Sensors (under the Edit section) > *C
 
 Two main sections can be distinguished in this tool, labeled *source* and *destination*. The source section is intended to display the signal attributes of locators, but it also displays any other float attributes. Meanwhile, the destination section will display the muscle deformers along with their possible input attributes.
 
-To retrieve these objects and display them in the tool, select the desired element from the scene (an AdonisFX locator containing a sensor or a deformer) and press their respective *Reload Left* or *Reload Right* button.
+To retrieve these objects and display them in the tool, select the desired element from the scene (an Adonis locator containing a sensor or a deformer) and press their respective *Reload Left* or *Reload Right* button.
 
 For Source elements (locators) press the *Reload Left* button and for Destination elements (muscle deformers) press the *Reload Right* button.
 

--- a/docs/maya/tools/turbo_tool.md
+++ b/docs/maya/tools/turbo_tool.md
@@ -1,6 +1,6 @@
 # AdnTurbo
 
-The **AdnTurbo Tool** is a feature designed to automate the creation of an AdonisFX rig from scratch on a clean asset within Maya, from which fine-tuning and customization can proceed. It sequentially configures the following layers:
+The **AdnTurbo Tool** is a feature designed to automate the creation of an Adonis rig from scratch on a clean asset within Maya, from which fine-tuning and customization can proceed. It sequentially configures the following layers:
 
 - **Muscle layer**
 - **Locators and Sensors**
@@ -61,11 +61,11 @@ Note that if any input is wrong or missing, the corresponding input text will tu
 
 3. Additionally, to place the output glue geometry in a specific group, check the *Group* option and provide a *Group name* in the *Glue Layer* UI group. Likewise, to place locator and rivet nodes into their own group, use the same options in the counterpart group *Locators & Sensors*. If the specified group does not exist, checking the *Create if not exist* option will make AdnTurbo to create it automatically.
 
-4. If the scene contains AdonisFX nodes, a confirmation dialog will appear informing about it. Press *Yes* to automatically delete all AdonisFX nodes or *No* to cancel the execution.
+4. If the scene contains Adonis nodes, a confirmation dialog will appear informing about it. Press *Yes* to automatically delete all Adonis nodes or *No* to cancel the execution.
 
 <figure style="width:90%; margin-left:5%" markdown>
   ![Turbo Execution Completed](../images/turbo_tool_confirmation_dialog.png)
-  <figcaption><b>Figure 5</b>: Question dialog informing about AdonisFX nodes in the scene before executing.</figcaption>
+  <figcaption><b>Figure 5</b>: Question dialog informing about Adonis nodes in the scene before executing.</figcaption>
 </figure>
 
 5. If something goes wrong during the execution, an error dialog will be displayed informing about the problem to help with the troubleshooting. Note that the whole AdnTurbo can be undone.
@@ -86,7 +86,7 @@ Note that if any input is wrong or missing, the corresponding input text will tu
 As a result of executing the tool by providing the geometries for all the layers, the following nodes will be created:
 
 - An AdnMuscle for each muscle geometry with the mummy geometries as targets.
-- An AdonisFX locator and sensor for each AdnMuscle to drive the muscle activation.
+- An Adonis locator and sensor for each AdnMuscle to drive the muscle activation.
 - An AdnGlue node (including its glue output geometry) with all the muscles as inputs.
 - An AdnSkin node for the fascia geometry with the mummy and glue geometries as targets.
 - An AdnRelax node applied on top of the fascia AdnSkin.
@@ -97,6 +97,6 @@ As a result of executing the tool by providing the geometries for all the layers
 ## Limitations
 
 - The **Glue Layer** cannot be bypassed. This means that for the **Fascia Layer** to be enabled, the **Glue Layer** checkbox must be checked.
-- If the *Yes* button is pressed in the question dialog (see Figure 5) the tool will automatically remove all the AdonisFX nodes from the scene. However, other auxiliary nodes created in previous executions of the script will not be removed (i.e. glue output geometry, rivet nodes).
+- If the *Yes* button is pressed in the question dialog (see Figure 5) the tool will automatically remove all the Adonis nodes from the scene. However, other auxiliary nodes created in previous executions of the script will not be removed (i.e. glue output geometry, rivet nodes).
 - The default values that AdnTurbo will use to configure each deformer cannot be customized.
 - AdnTurbo does not support namespaces in object paths.

--- a/docs/maya/ui_overview.md
+++ b/docs/maya/ui_overview.md
@@ -1,61 +1,61 @@
 # UI Overview
 
-The AdonisFX UI for Maya can be separated into two main elements presented in this page: the **AdonisFX Shelf** and the **AdonisFX Menu**.
+The Adonis UI for Maya can be separated into two main elements presented in this page: the **Adonis Shelf** and the **Adonis Menu**.
 
-## AdonisFX Shelf
+## Adonis Shelf
 
-The AdonisFX Shelf can be found in the Maya shelf tab under the label *AdonisFX*. It allows for quick access to the main AdonisFX functionalities.
+The Adonis Shelf can be found in the Maya shelf tab under the label *Adonis*. It allows for quick access to the main Adonis functionalities.
 
 <figure style="width: 100%;" markdown>
   ![AdnLocatorPosition within a scene](images/ui_overview_shelf.png)
-  <figcaption><b>Figure 1</b>: AdonisFX shelf.</figcaption>
+  <figcaption><b>Figure 1</b>: Adonis shelf.</figcaption>
 </figure>
 
 | Icon | Description | Menu Shortcut |
 | :--- | :---------- | :------------ |
 | ![AdnLocator](images/adn_adonis_locator.png) | Creates an AdnLocator at the origin. This object is a standard Maya locator with a custom shape for better visualization in the viewport. | |
-| ![AdnLocatorPosition](../images/adn_point_locator.png) | Creates an AdnLocatorPosition from the selected transform node. The locator shape represents the position change of the element provided. Double click will launch a simple UI to provide a custom name for the node. | AdonisFX Menu > Create Locators > *Position* |
-| ![AdnLocatorDistance](../images/adn_distance_locator.png) | Creates an AdnLocatorDistance from the two selected transform nodes. The locator shape represents the distance between the two elements provided. Double click will launch a simple UI to provide a custom name for the node. | AdonisFX Menu > Create Locators > *Distance* |
-| ![AdnLocatorRotation](../images/adn_angle_locator.png) | Creates an AdnLocatorRotation from the three selected transform nodes. The locator shape corresponds to the angle between the two segments represented by the three nodes. Double click will launch a simple UI to provide a custom name for the node. | AdonisFX Menu > Create Locators > *Rotation* |
+| ![AdnLocatorPosition](../images/adn_point_locator.png) | Creates an AdnLocatorPosition from the selected transform node. The locator shape represents the position change of the element provided. Double click will launch a simple UI to provide a custom name for the node. | Adonis Menu > Create Locators > *Position* |
+| ![AdnLocatorDistance](../images/adn_distance_locator.png) | Creates an AdnLocatorDistance from the two selected transform nodes. The locator shape represents the distance between the two elements provided. Double click will launch a simple UI to provide a custom name for the node. | Adonis Menu > Create Locators > *Distance* |
+| ![AdnLocatorRotation](../images/adn_angle_locator.png) | Creates an AdnLocatorRotation from the three selected transform nodes. The locator shape corresponds to the angle between the two segments represented by the three nodes. Double click will launch a simple UI to provide a custom name for the node. | Adonis Menu > Create Locators > *Rotation* |
 |||
-| ![AdnSensorPosition](../images/adn_point_sensor.png) | Creates an AdnSensorPosition from the transform object and the AdnLocatorPosition selected. If only the transform node is provided, then both the locator and the sensor are created. Double click will launch a simple UI to provide a custom name for the node. | AdonisFX Menu > Create Sensors > *Position* |
-| ![AdnSensorDistance](../images/adn_distance_sensor.png) | Creates an AdnSensorDistance from the two transform nodes and the AdnLocatorDistance selected. If only the transform nodes are provided, then both the locator and the sensor are created. Double click will launch a simple UI to provide a custom name for the node. | AdonisFX Menu > Create Sensors > *Distance* |
-| ![AdnSensorRotation](../images/adn_angle_sensor.png) | Creates an AdnSensorRotation from the three transform nodes and the AdnLocatorRotation selected. If only the transform nodes are provided, then both the locator and the sensor are created. Double click will launch a simple UI to provide a custom name for the node. | AdonisFX Menu > Create Sensors > *Rotation* |
+| ![AdnSensorPosition](../images/adn_point_sensor.png) | Creates an AdnSensorPosition from the transform object and the AdnLocatorPosition selected. If only the transform node is provided, then both the locator and the sensor are created. Double click will launch a simple UI to provide a custom name for the node. | Adonis Menu > Create Sensors > *Position* |
+| ![AdnSensorDistance](../images/adn_distance_sensor.png) | Creates an AdnSensorDistance from the two transform nodes and the AdnLocatorDistance selected. If only the transform nodes are provided, then both the locator and the sensor are created. Double click will launch a simple UI to provide a custom name for the node. | Adonis Menu > Create Sensors > *Distance* |
+| ![AdnSensorRotation](../images/adn_angle_sensor.png) | Creates an AdnSensorRotation from the three transform nodes and the AdnLocatorRotation selected. If only the transform nodes are provided, then both the locator and the sensor are created. Double click will launch a simple UI to provide a custom name for the node. | Adonis Menu > Create Sensors > *Rotation* |
 |||
-| ![Create AdnRibbonMuscle](../images/adn_ribbon_muscle.png) | Creates AdnRibbonMuscle deformer to the selected mesh. The deformer will be applied to the last element in the selection. Other elements in the list (optional) will be considered as target objects. Double click will launch a simple UI to assign a custom name and configure generic solver parameters. | AdonisFX Menu > Create Solvers > *Ribbon Muscle* |
-| ![Create AdnMuscle](../images/adn_muscle.png) | Creates AdnMuscle deformer to the selected mesh. The deformer will be applied to the last element in the selection. Other elements in the list (optional) will be considered as target objects. Double click will launch a simple UI to assign a custom name and configure generic solver parameters. | AdonisFX Menu > Create Solvers > *Muscle* |
-| ![Add Targets](images/adn_add_target.png) | Assigns target objects to the selected deformer (utility compatible with AdnRibbonMuscle and AdnMuscle deformers). The mesh with the deformer applied must be the last element in the selection. | AdonisFX Menu > Edit Muscle > *Add Targets* |
-| ![Remove Targets](images/adn_remove_target.png) | Removes target objects assigned to the selected deformer (utility compatible with AdnRibbonMuscle and AdnMuscle deformers). The mesh with the deformer applied must be the last element in the selection. | AdonisFX Menu > Edit Muscle > *Remove Targets* |
-| ![Add Slide On Segment](images/adn_add_sliding_constraint.png) | Adds slide segments based on the two (or more) transform objects and the mesh with the deformer node applied (utility compatible with AdnRibbonMuscle and AdnMuscle deformers). The mesh must be the last element in the selection. | AdonisFX Menu > Edit Muscle > *Add Slide On Segment* |
-| ![Remove Slide On Segment](images/adn_remove_sliding_constraint.png) | Removes slide segments assigned to the selected deformer (utility compatible with AdnRibbonMuscle and AdnMuscle deformers). The mesh with the deformer applied must be the last element in the selection. | AdonisFX Menu > Edit Muscle > *Remove Slide On Segment* |
-| ![Create AdnGlue](../images/adn_glue.png) | Creates an AdnGlue node and connects the selected geometries to the inputs array plug of the node. A new geometry will be generated as the result of gluing all the inputs together. | AdonisFX Menu > Create Solvers > *Glue* |
+| ![Create AdnRibbonMuscle](../images/adn_ribbon_muscle.png) | Creates AdnRibbonMuscle deformer to the selected mesh. The deformer will be applied to the last element in the selection. Other elements in the list (optional) will be considered as target objects. Double click will launch a simple UI to assign a custom name and configure generic solver parameters. | Adonis Menu > Create Solvers > *Ribbon Muscle* |
+| ![Create AdnMuscle](../images/adn_muscle.png) | Creates AdnMuscle deformer to the selected mesh. The deformer will be applied to the last element in the selection. Other elements in the list (optional) will be considered as target objects. Double click will launch a simple UI to assign a custom name and configure generic solver parameters. | Adonis Menu > Create Solvers > *Muscle* |
+| ![Add Targets](images/adn_add_target.png) | Assigns target objects to the selected deformer (utility compatible with AdnRibbonMuscle and AdnMuscle deformers). The mesh with the deformer applied must be the last element in the selection. | Adonis Menu > Edit Muscle > *Add Targets* |
+| ![Remove Targets](images/adn_remove_target.png) | Removes target objects assigned to the selected deformer (utility compatible with AdnRibbonMuscle and AdnMuscle deformers). The mesh with the deformer applied must be the last element in the selection. | Adonis Menu > Edit Muscle > *Remove Targets* |
+| ![Add Slide On Segment](images/adn_add_sliding_constraint.png) | Adds slide segments based on the two (or more) transform objects and the mesh with the deformer node applied (utility compatible with AdnRibbonMuscle and AdnMuscle deformers). The mesh must be the last element in the selection. | Adonis Menu > Edit Muscle > *Add Slide On Segment* |
+| ![Remove Slide On Segment](images/adn_remove_sliding_constraint.png) | Removes slide segments assigned to the selected deformer (utility compatible with AdnRibbonMuscle and AdnMuscle deformers). The mesh with the deformer applied must be the last element in the selection. | Adonis Menu > Edit Muscle > *Remove Slide On Segment* |
+| ![Create AdnGlue](../images/adn_glue.png) | Creates an AdnGlue node and connects the selected geometries to the inputs array plug of the node. A new geometry will be generated as the result of gluing all the inputs together. | Adonis Menu > Create Solvers > *Glue* |
 |||
-| ![Create AdnFat](../images/adn_fat.png) | Applies an AdnFat deformer to the selected mesh. The deformer will be applied to the second element in the selection, while the first element will be considered as base mesh. | AdonisFX Menu > Create Solvers > *Fat* |
+| ![Create AdnFat](../images/adn_fat.png) | Applies an AdnFat deformer to the selected mesh. The deformer will be applied to the second element in the selection, while the first element will be considered as base mesh. | Adonis Menu > Create Solvers > *Fat* |
 |||
-| ![Create AdnSkin](../images/adn_skin.png) | Creates AdnSkin deformer to the selected mesh. The deformer will be applied to the last element in the selection. Other elements in the list (optional) will be considered as target meshes. Double click will launch a simple UI to assign a custom name and configure generic solver parameters. | AdonisFX Menu > Create Solvers > *Skin* |
-| ![Add Targets](images/adn_add_skin_targets.png) | Assigns target meshes to the selected AdnSkin deformer. The mesh with the deformer applied must be the last element in the selection. | AdonisFX Menu > Edit Skin > *Add Targets* |
-| ![Remove Targets](images/adn_remove_skin_targets.png) | Removes target meshes assigned to the selected AdnSkin deformer. The mesh with the deformer applied must be the last element in the selection. | AdonisFX Menu > Edit Skin > *Remove Targets* |
+| ![Create AdnSkin](../images/adn_skin.png) | Creates AdnSkin deformer to the selected mesh. The deformer will be applied to the last element in the selection. Other elements in the list (optional) will be considered as target meshes. Double click will launch a simple UI to assign a custom name and configure generic solver parameters. | Adonis Menu > Create Solvers > *Skin* |
+| ![Add Targets](images/adn_add_skin_targets.png) | Assigns target meshes to the selected AdnSkin deformer. The mesh with the deformer applied must be the last element in the selection. | Adonis Menu > Edit Skin > *Add Targets* |
+| ![Remove Targets](images/adn_remove_skin_targets.png) | Removes target meshes assigned to the selected AdnSkin deformer. The mesh with the deformer applied must be the last element in the selection. | Adonis Menu > Edit Skin > *Remove Targets* |
 |||
-| ![Create AdnRelax](../images/adn_relax.png) | Applies an AdnRelax deformer to the selected mesh. | AdonisFX Menu > Create Deformers > *Relax* |
-| ![Create AdnPush](../images/adn_push.png) | Applies an AdnPush deformer to the selected mesh. | AdonisFX Menu > Create Deformers > *Push* |
-| ![Create AdnSkinMerge](../images/adn_skin_merge.png) | Launches the Create Skin Merge UI used to create an AdnSkinMerge deformer. | AdonisFX Menu > Create Deformers > *Skin Merge* |
+| ![Create AdnRelax](../images/adn_relax.png) | Applies an AdnRelax deformer to the selected mesh. | Adonis Menu > Create Deformers > *Relax* |
+| ![Create AdnPush](../images/adn_push.png) | Applies an AdnPush deformer to the selected mesh. | Adonis Menu > Create Deformers > *Push* |
+| ![Create AdnSkinMerge](../images/adn_skin_merge.png) | Launches the Create Skin Merge UI used to create an AdnSkinMerge deformer. | Adonis Menu > Create Deformers > *Skin Merge* |
 |||
-| ![Create AdnSimshape](../images/adn_simshape.png) | Applies an AdnSimshape deformer to the selected mesh. Double click will launch a simple UI to assign a custom name and configure generic solver parameters. | AdonisFX Menu > Create Solvers > *Simshape* |
-| ![Add AdnSimshape Collider](images/adn_add_collider.png) | Adds a collider to AdnSimshape selecting the collider and the mesh with AdnSimshape applied. | AdonisFX Menu > Edit Simshape > *Add Collider* |
-| ![Remove AdnSimshape Collider](images/adn_remove_collider.png) | Removes a collider from AdnSimshape selecting the collider and the mesh with AdnSimshape applied. | AdonisFX Menu > Edit Simshape > *Remove Collider* |
-| ![AdnSimshape Learn Muscle Patches Tool](../images/adn_learn_muscle_patches.png) | Launches the Learn Muscle Patches UI used to generate the *AdonisFX Muscle Patches* file (.amp) file. | AdonisFX Menu > Edit Simshape > *Learn Muscle Patches UI* |
-| ![AdnSimshape Activations Debugger](images/adn_simshape_debugger.png) | Toggles the AdnSimshape activations debug mode. The current frame has to match the preroll or start frame in the AdnSimshape deformer for this toggle to work. | AdonisFX Menu > Edit Simshape > *Activations Debugger* |
+| ![Create AdnSimshape](../images/adn_simshape.png) | Applies an AdnSimshape deformer to the selected mesh. Double click will launch a simple UI to assign a custom name and configure generic solver parameters. | Adonis Menu > Create Solvers > *Simshape* |
+| ![Add AdnSimshape Collider](images/adn_add_collider.png) | Adds a collider to AdnSimshape selecting the collider and the mesh with AdnSimshape applied. | Adonis Menu > Edit Simshape > *Add Collider* |
+| ![Remove AdnSimshape Collider](images/adn_remove_collider.png) | Removes a collider from AdnSimshape selecting the collider and the mesh with AdnSimshape applied. | Adonis Menu > Edit Simshape > *Remove Collider* |
+| ![AdnSimshape Learn Muscle Patches Tool](../images/adn_learn_muscle_patches.png) | Launches the Learn Muscle Patches UI used to generate the *Adonis Muscle Patches* file (.amp) file. | Adonis Menu > Edit Simshape > *Learn Muscle Patches UI* |
+| ![AdnSimshape Activations Debugger](images/adn_simshape_debugger.png) | Toggles the AdnSimshape activations debug mode. The current frame has to match the preroll or start frame in the AdnSimshape deformer for this toggle to work. | Adonis Menu > Edit Simshape > *Activations Debugger* |
 |||
-| ![Paint Tool](images/adn_paint_tool.png) | Opens the AdonisFX Paint Tool to modify the paintable maps in AdnSkin, AdnMuscle and AdnRibbonMuscle deformers. | AdonisFX Menu > *Tools* Paint Tool |
-| ![Interactive Playback](images/adn_interactive_playback.png) | Enables Maya Interactive Playback. In this playback mode, dynamic interaction with objects and parameters while simulating is allowed. | AdonisFX Menu > Tools *Interactive Playback* |
+| ![Paint Tool](images/adn_paint_tool.png) | Opens the Adonis Paint Tool to modify the paintable maps in AdnSkin, AdnMuscle and AdnRibbonMuscle deformers. | Adonis Menu > *Tools* Paint Tool |
+| ![Interactive Playback](images/adn_interactive_playback.png) | Enables Maya Interactive Playback. In this playback mode, dynamic interaction with objects and parameters while simulating is allowed. | Adonis Menu > Tools *Interactive Playback* |
 
-## AdonisFX Menu
+## Adonis Menu
 
-The AdonisFX Menu provides access to the options in the shelf and other more advanced utilities that are organized in six groups: Create, Edit, Tools, I/O, License and Help.
+The Adonis Menu provides access to the options in the shelf and other more advanced utilities that are organized in six groups: Create, Edit, Tools, I/O, License and Help.
 
 <figure style="width: 30%;" markdown>
   ![AdnLocatorPosition within a scene](images/ui_overview_menu.png)
-  <figcaption><b>Figure 2</b>: AdonisFX Menu.</figcaption>
+  <figcaption><b>Figure 2</b>: Adonis Menu.</figcaption>
 </figure>
 
 ### Create Section
@@ -102,7 +102,7 @@ Both in Locators and Sensors there are option boxes to launch a simple UI to pro
 Option boxes can be used to launch a UI to assign the name to the deformer and configure generic solver parameters.
 
 <figure style="width: 50%;" markdown>
-  ![AdonisFX AdnSkin Deformer Creator](images/ui_overview_skin_deformer_creator.png)
+  ![Adonis AdnSkin Deformer Creator](images/ui_overview_skin_deformer_creator.png)
   <figcaption><b>Figure 4</b>: Deformer Creator UI creating for an AdnSkin deformer.</figcaption>
 </figure>
 
@@ -110,7 +110,7 @@ Option boxes can be used to launch a UI to assign the name to the deformer and c
 
 #### Sensors
 
-- **Connection Editor**. Launches the Sensors Connection Editor UI. This tool will assist with the connection of the locators and sensors output plugs with the AdonisFX deformer nodes.
+- **Connection Editor**. Launches the Sensors Connection Editor UI. This tool will assist with the connection of the locators and sensors output plugs with the Adonis deformer nodes.
 
 #### Activation
 
@@ -147,7 +147,7 @@ Option boxes can be used to launch a UI to assign the name to the deformer and c
 
 #### Simshape
 
-- **Learn Muscle Patches UI**. Launches the Learn Muscle Patches UI required to generate the *AdonisFX Muscle Patches* (.amp) file. This item corresponds to the shelf button ![AdnSimshape Learn Muscle Patches Tool](../images/adn_learn_muscle_patches.png){style="width:4%"}.
+- **Learn Muscle Patches UI**. Launches the Learn Muscle Patches UI required to generate the *Adonis Muscle Patches* (.amp) file. This item corresponds to the shelf button ![AdnSimshape Learn Muscle Patches Tool](../images/adn_learn_muscle_patches.png){style="width:4%"}.
 - **Activations Debugger**. Toggles the AdnSimshape activations debug mode. The current frame must match the specified initialization frame at the AdnSimshape deformer to toggle. This item corresponds to the shelf button ![AdnSimshape Activations Debugger](images/adn_simshape_debugger.png){style="width:4%"}. 
 - **Add Collider**. Assigns the collider to the selected deformer. The selection must consist of: first the mesh to assign as a Collider and lastly the mesh with the deformer applied. This item corresponds to the shelf button ![Add AdnSimshape Collider](images/adn_add_collider.png){style="width:4%"}. 
 - **Remove Collider**. Removes the collider from the selected deformer. The selection must consist of: first the Collider mesh to remove and lastly the mesh with the deformer applied. This item corresponds to the shelf button ![Remove AdnSimshape Collider](images/adn_remove_collider.png){style="width:4%"}. 
@@ -172,20 +172,20 @@ Option boxes can be used to launch a UI to assign the name to the deformer and c
 
 ### Tools section
 
-- **Utils > Clear**. Removes all AdonisFX nodes from the scene.
-- **Utils > Upgrade v1.x To v2.x**. Performs an upgrade to all AdonisFX solvers to make v1.x rigs compatible with v2.x. This upgrade affects the painted values in the maps that are affected by the *Maps Remap Mode* attribute added in v2.0.0 to all solvers (i.e., shape preservation, attachments and sliding in muscle solver, uber constraints in skin solver). Due to how this remapping modifies how the painted values from the plugs are transferred to the solver, this utility updates those values in order to get simulation results as consistent as possible with v1.x. Additionally, since the *Concrete* material has been deprecated, this upgrade script also checks whether any nodes in the scene are using an invalid material. If an invalid material is found, it will be automatically replaced with the default material.
+- **Utils > Clear**. Removes all Adonis nodes from the scene.
+- **Utils > Upgrade v1.x To v2.x**. Performs an upgrade to all Adonis solvers to make v1.x rigs compatible with v2.x. This upgrade affects the painted values in the maps that are affected by the *Maps Remap Mode* attribute added in v2.0.0 to all solvers (i.e., shape preservation, attachments and sliding in muscle solver, uber constraints in skin solver). Due to how this remapping modifies how the painted values from the plugs are transferred to the solver, this utility updates those values in order to get simulation results as consistent as possible with v1.x. Additionally, since the *Concrete* material has been deprecated, this upgrade script also checks whether any nodes in the scene are using an invalid material. If an invalid material is found, it will be automatically replaced with the default material.
 As a final step to support the addition of the *currentTime* plug in AdnSkinMerge we provide inside of the upgrade process a way to connect the *time1.outTime* to every node that has a *currentTime* plug.
-- **Utils > Reconnect Current Time**. Connected the *time1.outTime* plug to all the AdonisFX nodes that have a *currentTime* plug for correct time dependency for its evaluation. 
+- **Utils > Reconnect Current Time**. Connected the *time1.outTime* plug to all the Adonis nodes that have a *currentTime* plug for correct time dependency for its evaluation. 
 
 - **Mirror**. Opens the Mirror Tool UI which allows to mirror the muscle setup (locators, sensors and muscles) from one side of the character to the other based on left and right naming rules.
-- **Turbo**. Opens the Turbo UI, which allows users to build an AdonisFX rig on a clean asset from scratch. The UI is divided into sections for each simulation layer that the AdnTurbo can configure. Users can toggle layers on or off to include or skip them in the execution and select the scene objects required to create and configure the solvers.
+- **Turbo**. Opens the Turbo UI, which allows users to build an Adonis rig on a clean asset from scratch. The UI is divided into sections for each simulation layer that the AdnTurbo can configure. Users can toggle layers on or off to include or skip them in the execution and select the scene objects required to create and configure the solvers.
 - **Paint Tool**. Opens the Paint Tool UI to modify the paintable maps in AdnSkin, AdnMuscle and AdnRibbonMuscle deformers. This item corresponds to the shelf button ![Paint Tool](images/adn_paint_tool.png){style="width:4%"}.
 - **Interactive Playback**. Enables Maya Interactive Playback. In this playback mode, dynamic interaction with objects and parameters while simulating is allowed. This item corresponds to the shelf button ![Interactive Playback](images/adn_interactive_playback.png){style="width:4%"}.
 
 ### I/O section
 
-- **Import (beta)**. Opens the Import UI which allows to import an AdonisFX rig from a file in disk into the scene.
-- **Export (beta)**. Opens the Export UI which allows to export an AdonisFX rig from the scene into a file in disk.
+- **Import (beta)**. Opens the Import UI which allows to import an Adonis rig from a file in disk into the scene.
+- **Export (beta)**. Opens the Export UI which allows to export an Adonis rig from the scene into a file in disk.
 
 ### License section
 
@@ -193,6 +193,6 @@ As a final step to support the addition of the *currentTime* plug in AdnSkinMerg
 
 ### Help section
 
-- **Documentation**. Opens the AdonisFX technical documentation on a web browser.
-- **Tutorials**. Opens the AdonisFX tutorials on YouTube on a web browser.
-- **About**. Launches the AdonisFX About dialog with version information and credits.
+- **Documentation**. Opens the Adonis technical documentation on a web browser.
+- **Tutorials**. Opens the Adonis tutorials on YouTube on a web browser.
+- **About**. Launches the Adonis About dialog with version information and credits.

--- a/docs/maya/utils/activation.md
+++ b/docs/maya/utils/activation.md
@@ -9,7 +9,7 @@ To create this node, follow these steps:
 1. Open the Node Editor from Windows > Node Editor.
 2. Press the Tab key, type *AdnActivation* and press Enter to create a new instance of this node.
 
-Alternatively, press the option located in AdonisFX > Nodes > *Activation* to create a new AdnActivation node. Additional information about this option can be found in the [Advanced](activation#advanced) section.
+Alternatively, press the option located in Adonis > Nodes > *Activation* to create a new AdnActivation node. Additional information about this option can be found in the [Advanced](activation#advanced) section.
 
 The activation node can now be used to override, add, subtract, multiply or divide the activations from different sources (sensors) into one final activation value.
 For example, multiple distance sensors of a character can be merged together to produce different kinds of activations throughout the simulation.
@@ -23,7 +23,7 @@ To add new inputs to the AdnActivation node:
 
 1. Go to the Attribute Editor and press *Add New Item*.
 2. Set the desired *Operator*.
-3. Type in a fixed value in *Value*, animate it or connect the plug with an AdonisFX sensor's output.
+3. Type in a fixed value in *Value*, animate it or connect the plug with an Adonis sensor's output.
 
 > [!NOTE]
 > All operators will be evaluated from top to bottom (starting from the lowest index and ending on the last index used).
@@ -86,22 +86,22 @@ The *inputs* attribute is presented as an array of 3 attributes which can be fou
 
 ### Create AdnActivation
 
-It is possible to create an AdnActivation node by using the utility provided in AdonisFX > Nodes > *Activation*. This utility will create a new AdnActivation node. If muscle deformers are provided in the selection, the new AdnActivation node will be connected to the activation plug of those deformers.
+It is possible to create an AdnActivation node by using the utility provided in Adonis > Nodes > *Activation*. This utility will create a new AdnActivation node. If muscle deformers are provided in the selection, the new AdnActivation node will be connected to the activation plug of those deformers.
 
 ### Remove Inputs
 
-Once an AdnActivation node is created, connected inputs can be removed by using the utility provided in AdonisFX > Activation > *Remove Inputs*.
+Once an AdnActivation node is created, connected inputs can be removed by using the utility provided in Adonis > Activation > *Remove Inputs*.
 
 - **Remove Inputs** by providing an AdnActivation node:
     1. Select the locators to remove from the AdnActivation node.
     2. Select the AdnActivation node.
-    3. Press *Remove Inputs* in the AdonisFX menu from the Edit Activation submenu.
+    3. Press *Remove Inputs* in the Adonis menu from the Edit Activation submenu.
     4. Alternatively, if only the AdnActivation node is selected, when pressing *Remove Inputs*, all inputs will be removed.
 
 - **Remove Inputs** by providing a muscle deformer:
     1. Select the locators to remove from the AdnActivation node.
     2. Select the mesh with a muscle deformer applied that is connected to an AdnActivation node.
-    3. Press *Remove Inputs* in the AdonisFX menu from the Edit Activation submenu to remove the inputs from the AdnActivation node.
+    3. Press *Remove Inputs* in the Adonis menu from the Edit Activation submenu to remove the inputs from the AdnActivation node.
     4. Alternatively, if only the mesh with a muscle deformer applied is selected, when pressing *Remove Inputs*, all inputs will be removed from the AdnActivation node.
 
 > [!NOTE]

--- a/docs/maya/utils/edge_evaluator.md
+++ b/docs/maya/utils/edge_evaluator.md
@@ -15,7 +15,7 @@ This node requires the following inputs to be provided:
 To create this node, follow these steps:
 
 1. Select the deform mesh, then the rest mesh.
-2. Go to the AdonisFX menu > Create Nodes > *Edge Evaluator*.
+2. Go to the Adonis menu > Create Nodes > *Edge Evaluator*.
 
 The evaluator node can be used to drive the activations of an AdnSimshape deformer by connecting the output map of this node to the activations plug of AdnSimshape deformer. The *Plug Values* mode (see this [section](../solvers/simshape#muscle-activations)) must be enabled.
 
@@ -27,7 +27,7 @@ The evaluator node can be used to drive the activations of an AdnSimshape deform
 A menu option is provided to recreate these steps easily:
 
 1. Select the Edge Evaluator Node, then the AdnSimshape deformer node.
-2. Go to the AdonisFX Menu > Edit Simshape > *Connect Activations Plug*.
+2. Go to the Adonis Menu > Edit Simshape > *Connect Activations Plug*.
 
 In order to disconnect the plug, repeat the selection and instead of pressing *Connect Activations Plug* press *Disconnect Activations Plug*.
 

--- a/docs/maya/utils/locators.md
+++ b/docs/maya/utils/locators.md
@@ -1,6 +1,6 @@
 # Locators
 
-AdonisFX Locators are visualizers that are meant for visualizing and measuring transform nodes which provide valuable input information for setting up the deformers. They can visualize information representing position, distance, or angle as well as velocities or accelerations represented via coloring when used in combination with Sensors.
+Adonis Locators are visualizers that are meant for visualizing and measuring transform nodes which provide valuable input information for setting up the deformers. They can visualize information representing position, distance, or angle as well as velocities or accelerations represented via coloring when used in combination with Sensors.
 
 ## AdnLocatorPosition
 
@@ -18,7 +18,7 @@ An AdnLocatorPosition will only visualize the information of the transform node 
 Only one transform will be required to create the AdnLocatorPosition. The creation process is the following:
 
  1. Select a transform node in the scene.
- 2. Press the ![AdnLocatorPosition button](../../images/adn_point_locator.png){style="width:4%"} button in the AdonisFX shelf or press *Position* in the AdonisFX menu, under the *Locators* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+ 2. Press the ![AdnLocatorPosition button](../../images/adn_point_locator.png){style="width:4%"} button in the Adonis shelf or press *Position* in the Adonis menu, under the *Locators* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
  3. The AdnLocatorPosition is created and ready to be used.
 
 
@@ -65,7 +65,7 @@ An AdnLocatorDistance will only visualize the information of the distance betwee
 Two transform nodes will be required to create an AdnLocatorDistance representing each extremity. The creation process is the following:
 
  1. Select two transform nodes in the scene.
- 2. Press the ![AdnLocatorDistance button](../../images/adn_distance_locator.png){style="width:4%"} button in the AdonisFX shelf or press *Distance* in the AdonisFX menu, under the *Locators* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+ 2. Press the ![AdnLocatorDistance button](../../images/adn_distance_locator.png){style="width:4%"} button in the Adonis shelf or press *Distance* in the Adonis menu, under the *Locators* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
  3. The AdnLocatorDistance is created and ready to be used.
 
 ### Attributes
@@ -117,7 +117,7 @@ Three transform nodes will be required to create the AdnLocatorRotation. The cre
     - First selected object: Start point of the angle.
     - Second selected object: Middle point of the angle.
     - Third selected object: End point of the angle.
- 2. Press the ![AdnLocatorRotation button](../../images/adn_angle_locator.png){style="width:4%"} button in the AdonisFX shelf or press *Rotation* in the AdonisFX menu, under the *Locators* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+ 2. Press the ![AdnLocatorRotation button](../../images/adn_angle_locator.png){style="width:4%"} button in the Adonis shelf or press *Rotation* in the Adonis menu, under the *Locators* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
  3. The AdnLocatorRotation is created and ready to be used.
 
 ### Attributes
@@ -154,11 +154,11 @@ Three transform nodes will be required to create the AdnLocatorRotation. The cre
 
 ## AdnLocator
 
-The AdnLocator is an native alternative to Maya locators. This locator can be used to visualize any kind of scene element with a transform node. For example they can be used as inputs to other AdonisFX locators presented in this page.
+The AdnLocator is an native alternative to Maya locators. This locator can be used to visualize any kind of scene element with a transform node. For example they can be used as inputs to other Adonis locators presented in this page.
 
 ### How To Use
 
-To create an AdnLocator just click on the ![AdonisFX Logo locator button](../images/adn_adonis_locator.png){style="width:4%"} button in the AdonisFX shelf. The locator will be created at the origin of your scene.
+To create an AdnLocator just click on the ![Adonis Logo locator button](../images/adn_adonis_locator.png){style="width:4%"} button in the Adonis shelf. The locator will be created at the origin of your scene.
 
 <figure markdown>
   ![AdnLocator within a scene](../images/locators_adonis.png)

--- a/docs/maya/utils/remap.md
+++ b/docs/maya/utils/remap.md
@@ -1,6 +1,6 @@
 # AdnRemap
 
-The AdnRemap node is an AdonisFX node that aims to provide the same key functionalities that a Maya remapValue node has. This node type is typically used in an AdonisFX rig, for example, to remap the output of a sensor into a value to drive muscle activation or volume ratio gain. The objective of using AdnRemap nodes instead of Maya remapValue nodes is to enhance the portability of the whole AdonisFX rig, including not only the input and output connections but also the configuration of the remap ramp attribute.
+The AdnRemap node is an Adonis node that aims to provide the same key functionalities that a Maya remapValue node has. This node type is typically used in an Adonis rig, for example, to remap the output of a sensor into a value to drive muscle activation or volume ratio gain. The objective of using AdnRemap nodes instead of Maya remapValue nodes is to enhance the portability of the whole Adonis rig, including not only the input and output connections but also the configuration of the remap ramp attribute.
 
 ## How To Use
 
@@ -9,9 +9,9 @@ An instance of this node can be created from the Node Editor:
 1. Open the Node Editor from Windows > Node Editor.
 2. Press the Tab key, type *AdnRemap* and press Enter to create a new instance of this node.
 
-Typically, this node will be used to remap the raw output values of AdonisFX sensors (i.e. distance, angle, velocity and acceleration) so that they are ingested into the AdonisFX locators within the desired normalized ranges. The remapped output can also be ingested directly in an AdnMuscle deformer to modulate, for example, the activation or the volume ratio.
+Typically, this node will be used to remap the raw output values of Adonis sensors (i.e. distance, angle, velocity and acceleration) so that they are ingested into the Adonis locators within the desired normalized ranges. The remapped output can also be ingested directly in an AdnMuscle deformer to modulate, for example, the activation or the volume ratio.
 
-Starting from a scene with an AdonisFX rig already configured using Maya remapValue nodes, it is possible to upgrade the entire node graph by replacing all those Maya nodes by AdnRemap nodes preserving their settings and connections. For that, run the following code in a Python Script Editor tab:
+Starting from a scene with an Adonis rig already configured using Maya remapValue nodes, it is possible to upgrade the entire node graph by replacing all those Maya nodes by AdnRemap nodes preserving their settings and connections. For that, run the following code in a Python Script Editor tab:
 
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.utils.maya import graph
 graph.upgrade_remap_nodes(delete=True)
@@ -24,7 +24,7 @@ graph.upgrade_remap_nodes(delete=True)
 ## Example
 
 <figure markdown>
-  ![AdnRemap nodes used to remap AdonisFX sensors outputs](../images/remap_example.png)
+  ![AdnRemap nodes used to remap Adonis sensors outputs](../images/remap_example.png)
   <figcaption><b>Figure 1</b>: Use case in which different AdnRemap nodes are used in the node history of an AdnMuscle to drive the muscle's activation and volume gain.</figcaption>
 </figure>
 

--- a/docs/maya/utils/sensors.md
+++ b/docs/maya/utils/sensors.md
@@ -1,14 +1,14 @@
 # Sensors
 
-AdonisFX Sensors are nodes in charge of interpreting data extracted from transform nodes and compute information that can be fed into the deformers to alter their behavior. Sensors work in combination with [Locators](locators) to display the computed information in an intuitive way using coloring. The sensors produce the results in two separated outputs: the raw value result of the evaluation of the input transform nodes (e.g. *Out Angle*); and the remapped value result of the evaluation of the raw value into the existing remap ramp attributes (e.g. *Out Angle Remap*). Thanks to this, the remapped values are already adjusted within a custom range of activation that will drive the coloring of the locators and the activation of an AdnMuscle for example.
+Adonis Sensors are nodes in charge of interpreting data extracted from transform nodes and compute information that can be fed into the deformers to alter their behavior. Sensors work in combination with [Locators](locators) to display the computed information in an intuitive way using coloring. The sensors produce the results in two separated outputs: the raw value result of the evaluation of the input transform nodes (e.g. *Out Angle*); and the remapped value result of the evaluation of the raw value into the existing remap ramp attributes (e.g. *Out Angle Remap*). Thanks to this, the remapped values are already adjusted within a custom range of activation that will drive the coloring of the locators and the activation of an AdnMuscle for example.
 
 ## AdnSensorPosition
 
-AdnSensorPosition is the sensor for computing meaningful output raw values representing the velocity or acceleration of a transform node. Additionally, the sensor remaps the values of velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an AdonisFX deformer. This sensor has to work in combination with an AdnLocatorPosition both for setup and visualization. An example use case for this sensor would be applying it to the wrist connection of an arm outputting velocities while swinging.
+AdnSensorPosition is the sensor for computing meaningful output raw values representing the velocity or acceleration of a transform node. Additionally, the sensor remaps the values of velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an Adonis deformer. This sensor has to work in combination with an AdnLocatorPosition both for setup and visualization. An example use case for this sensor would be applying it to the wrist connection of an arm outputting velocities while swinging.
 
 ### How To Use
 
-An AdnSensorPosition will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorPosition for visualization purposes, which in turn feeds the AdonisFX deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
+An AdnSensorPosition will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorPosition for visualization purposes, which in turn feeds the Adonis deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
 
 <figure markdown>
   ![AdnSensorPosition velocity display on AdnLocatorPosition within a scene](../images/sensors_position.png)
@@ -20,13 +20,13 @@ There are two different methods of creating an AdnSensorPosition, depending if i
  - If applying to an already existing AdnLocatorPosition:
 
     1. Select an AdnLocatorPosition from your scene.
-    2. Press the ![AdnSensorPosition button](../../images/adn_point_sensor.png){style="width:4%"} button in the AdonisFX shelf or press *Position* in the AdonisFX menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+    2. Press the ![AdnSensorPosition button](../../images/adn_point_sensor.png){style="width:4%"} button in the Adonis shelf or press *Position* in the Adonis menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
     3. The AdnSensorPosition is created, applied to the selected AdnLocatorPosition.
 
  - If creating the locator alongside the sensor:
 
     1. Select a transform node in the scene.
-    2. Press the ![AdnSensorPosition button](../../images/adn_point_sensor.png){style="width:4%"} button in the AdonisFX shelf or press *Position* in the AdonisFX menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+    2. Press the ![AdnSensorPosition button](../../images/adn_point_sensor.png){style="width:4%"} button in the Adonis shelf or press *Position* in the Adonis menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
     3. The AdnSensorPosition is created, alongside a new AdnLocatorPosition applied to the same transform node.
 
 <figure markdown>
@@ -109,11 +109,11 @@ There are two different methods of creating an AdnSensorPosition, depending if i
 
 ## AdnSensorDistance
 
-AdnSensorDistance is the sensor for computing meaningful output raw values representing the distance, velocity or acceleration between two transform nodes. Additionally, the sensor remaps the values of distance, velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an AdonisFX deformer. This sensor has to work in combination with an AdnLocatorDistance both for setup and visualization. An example use case for this sensor would be applying it to the connection made between bones which would compute the distance between two bones moving together.
+AdnSensorDistance is the sensor for computing meaningful output raw values representing the distance, velocity or acceleration between two transform nodes. Additionally, the sensor remaps the values of distance, velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an Adonis deformer. This sensor has to work in combination with an AdnLocatorDistance both for setup and visualization. An example use case for this sensor would be applying it to the connection made between bones which would compute the distance between two bones moving together.
 
 ### How To Use
 
-An AdnSensorDistance will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorDistance for visualization purposes, which in turn feeds the AdonisFX deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
+An AdnSensorDistance will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorDistance for visualization purposes, which in turn feeds the Adonis deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
 
 <figure markdown>
   ![AdnSensorDistance distance display on AdnLocatorDistance within a scene](../images/sensors_distance.png)
@@ -125,13 +125,13 @@ There are two different methods of creating an AdnSensorDistance, depending if i
  - If applying to an already existing AdnLocatorDistance:
 
     1. Select an AdnLocatorDistance from your scene.
-    2. Press the ![AdnSensorDistance button](../../images/adn_distance_sensor.png){style="width:4%"} button in the AdonisFX shelf or press *Distance* in the AdonisFX menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+    2. Press the ![AdnSensorDistance button](../../images/adn_distance_sensor.png){style="width:4%"} button in the Adonis shelf or press *Distance* in the Adonis menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
     3. The AdnSensorDistance is created, applied to the selected AdnLocatorDistance.
 
  - If creating the locator alongside the sensor:
 
     1. Select two transform nodes in the scene.
-    2. Press the ![AdnSensorDistance button](../../images/adn_distance_sensor.png){style="width:4%"} button in the AdonisFX shelf or press *Distance* in the AdonisFX menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+    2. Press the ![AdnSensorDistance button](../../images/adn_distance_sensor.png){style="width:4%"} button in the Adonis shelf or press *Distance* in the Adonis menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
     3. The AdnSensorDistance is created, alongside a new AdnLocatorDistance applied to the same transform nodes.
 
 <figure markdown>
@@ -235,11 +235,11 @@ There are two different methods of creating an AdnSensorDistance, depending if i
 
 ## AdnSensorRotation
 
-AdnSensorRotation is the sensor for computing meaningful output raw values representing the angle, angular velocity or angular acceleration between three transform nodes. Additionally, the sensor remaps the values of angle, velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an AdonisFX deformer. This sensor has to work in combination with an AdnLocatorRotation both for setup and visualization. An example use case for this sensor would be applying it to the arc connection made between bones which would compute the angle between two bones rotating.
+AdnSensorRotation is the sensor for computing meaningful output raw values representing the angle, angular velocity or angular acceleration between three transform nodes. Additionally, the sensor remaps the values of angle, velocity and acceleration to produce desirable activation values within a certain range to drive the simulation of an Adonis deformer. This sensor has to work in combination with an AdnLocatorRotation both for setup and visualization. An example use case for this sensor would be applying it to the arc connection made between bones which would compute the angle between two bones rotating.
 
 ### How To Use
 
-An AdnSensorRotation will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorRotation for visualization purposes, which in turn feeds the AdonisFX deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
+An AdnSensorRotation will be in charge of computing, remapping and feeding activation (or other) values into the AdnLocatorRotation for visualization purposes, which in turn feeds the Adonis deformers to drive the simulation. The value of the sensor can be used, for example, to drive the activation of a muscle simulating contraction to increase its stiffness.
 
 <figure markdown>
   ![AdnSensorRotation angle display on AdnLocatorRotation within a scene](../images/sensors_rotation.png)
@@ -251,13 +251,13 @@ There are two different methods of creating an AdnSensorRotation, depending if i
  - If applying to an already existing AdnLocatorRotation:
 
     1. Select an AdnLocatorRotation from your scene.
-    2. Press the ![AdnSensorRotation button](../../images/adn_angle_sensor.png){style="width:4%"} button in the AdonisFX shelf or press *Rotation* in the AdonisFX menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+    2. Press the ![AdnSensorRotation button](../../images/adn_angle_sensor.png){style="width:4%"} button in the Adonis shelf or press *Rotation* in the Adonis menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
     3. The AdnLocatorRotation is created, applied to the selected AdnLocatorRotation.
 
  - If creating the locator alongside the sensor:
 
     1. Select three transform nodes in the scene.
-    2. Press the ![AdnSensorRotation button](../../images/adn_angle_sensor.png){style="width:4%"} button in the AdonisFX shelf or press *Rotation* in the AdonisFX menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
+    2. Press the ![AdnSensorRotation button](../../images/adn_angle_sensor.png){style="width:4%"} button in the Adonis shelf or press *Rotation* in the Adonis menu, under the *Sensor* submenu. If the shelf button is double-clicked or the option box in the menu is selected a window will be displayed where a custom name and initial attribute values can be set.
     3. The AdnSensorRotation is created, alongside a new AdnLocatorRotation applied to the same transform nodes.
 
 <figure markdown>

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,7 @@
 2026-06-02
 
 ### Bug Fixes
-- Fixed a bug that was causing subframe evaluations to default to one frame timestep instead of the evaluated subframe timestep. *AdonisFX-3193*.
+- Fixed a bug that was causing subframe evaluations to default to one frame timestep instead of the evaluated subframe timestep. *Adonis-3193*.
 
 ## Version 2.0.0
 2026-03-04
@@ -31,7 +31,7 @@
 - Integrated art-directable shapes for muscle deformers.
 - Implemented substepping for AdnSimshape and muscle deformers.
 - Implemented *Update v1.x to v2.x* menu utility.
-- Added *Visualization Modes* to the AdonisFX Paint Tool, allowing *Greyscale* and *Heat Map* modes.
+- Added *Visualization Modes* to the Adonis Paint Tool, allowing *Greyscale* and *Heat Map* modes.
 - Added *Update on Topology Change* attribute for AdnPush and AdnRelax.
 - Modified default attribute values in most of the nodes.
 - Reordered shelf and menu items.
@@ -56,8 +56,8 @@
 
 - Implemented new nodes for the muscle fiber workflow, including: AdnFiberProjection, AdnFiberDiffusion, and AdnFiberGroom.
 - Implemented an experimental API.
-- Implemented the *Make Paintable* menu utility to simplify the process of painting maps for an AdonisFX solver.
-- Implemented the *Make Groomable* menu utility to simplify the setup of fiber directions for an AdonisFX muscle solver.
+- Implemented the *Make Paintable* menu utility to simplify the process of painting maps for an Adonis solver.
+- Implemented the *Make Groomable* menu utility to simplify the setup of fiber directions for an Adonis muscle solver.
 - Implemented the *Separate Geometries* menu utility to split geometry pieces based on a primitive attribute using blast nodes.
 - Implemented the *Create Muscle PieceID* menu utility to create a primitive attribute that identifies each geometry piece using a connectivity node.
 
@@ -68,7 +68,7 @@
 - Improved experimental API in Maya.
 - Added support for the new features in the *Importer* and *Exporter* tools.
 - Improved the Mirror Tool in Maya to support left and right tokens in the middle of names (e.g. \_L\_ and \_R\_).
-- Improved the Connection Editor in Maya to restrict connections to AdonisFX locators (source) and AdonisFX muscles (destination).
+- Improved the Connection Editor in Maya to restrict connections to Adonis locators (source) and Adonis muscles (destination).
 - Added support for multiple AdnRelax and AdnPush nodes on the same geometry in Maya.
 - Added support in the experimental API for rebuilding the rig using the correct execution order in Maya and Houdini.
 - Added currentTime attribute to AdnSkinMerge in Maya for correct dependency graph evaluation.
@@ -78,14 +78,14 @@
 - Removed AdnWeightsDisplayNode that was deprecated in version 1.4.0.
 
 ### Known Limitations
-- AdnGlue SOP node's debugger in Houdini does not display lines correctly after scene reopen. *AdonisFX-2870*
-- Maya 2026 producing undesired behaviors on scene open on a fully configured AdonisFX scene with hidden geometries and GPU Override enabled. *AdonisFX-2760*
+- AdnGlue SOP node's debugger in Houdini does not display lines correctly after scene reopen. *Adonis-2870*
+- Maya 2026 producing undesired behaviors on scene open on a fully configured Adonis scene with hidden geometries and GPU Override enabled. *Adonis-2760*
 
 ## Version 1.7.3
 2025-10-22
 
 ### Bug Fixes
-- Resolved an issue that caused the custom paint context to fail in Maya 2026. *AdonisFX-2419*
+- Resolved an issue that caused the custom paint context to fail in Maya 2026. *Adonis-2419*
 
 ## Version 1.7.2
 2025-06-12
@@ -95,13 +95,13 @@
 - Improved material switch in the Paint Tool to support multiple materials on the same paintable geometry.
 
 ### Bug Fixes
-- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *AdonisFX-2111*
+- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *Adonis-2111*
 
 ## Version 1.7.1
 2025-06-09
 
 ### Improvements
-- Improved logger to display more information in batch mode. *AdonisFX-2100*
+- Improved logger to display more information in batch mode. *Adonis-2100*
 
 ## Version 1.7.0
 2025-05-28
@@ -115,7 +115,7 @@
 - Added volume preservation to the AdnGlue solver.
 
 ### Maya
-- Added an AdnTurbo script to build the whole AdonisFX rig from Python.
+- Added an AdnTurbo script to build the whole Adonis rig from Python.
 - Implemented a UI to execute AdnTurbo.
 - Added dynamic attributes to the AdnGlue node (e.g. substeps, gravity, soft constraints, attenuation, damping).
 - Added volume preservation attribute to the AdnGlue node.
@@ -132,7 +132,7 @@
 - Improved AdnActivation node support in the Experimental API to support value plugs without connections.
 
 ### Bug Fixes
-- Fixed a bug that was preventing skipping the computation of the slide collision constraints when the Compute Collisions checkbox was disabled in AdnSimshape. *AdonisFX-2043*
+- Fixed a bug that was preventing skipping the computation of the slide collision constraints when the Compute Collisions checkbox was disabled in AdnSimshape. *Adonis-2043*
 
 ### Deprecated
 - Removed Python code (UI, tools and utils) that was supporting the outdated Import and Export tools deprecated in 1.5.0.
@@ -145,13 +145,13 @@
 - Improved material switch in the Paint Tool to support multiple materials on the same paintable geometry.
 
 ### Bug Fixes
-- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *AdonisFX-2111*
+- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *Adonis-2111*
 
 ## Version 1.6.3
 2025-06-06
 
 ### Improvements
-- Improved logger to display more information in batch mode. *AdonisFX-2100*
+- Improved logger to display more information in batch mode. *Adonis-2100*
 
 ## Version 1.6.2
 2025-04-25
@@ -208,8 +208,8 @@
 - Updated menu with new items: *Mirror*, *Export (beta)*, *Import (beta)* and *Clear*.
 - Updated locator creator utils to use input matrix plugs and remapping functionalities in sensors.
 - Updated sensor creator utils to use input matrix plugs and remapping functionalities in sensors.
-- Improved AdonisFX logger to display messages on idle.
-- Displayed warning log when both the AdonisFX debugger and the Maya Cached Playback are enabled.
+- Improved Adonis logger to display messages on idle.
+- Displayed warning log when both the Adonis debugger and the Maya Cached Playback are enabled.
 
 ### Bug Fixes
 - Fixed *Refresh Debugger* utility to support namespaces.
@@ -244,7 +244,7 @@
 
 ### Bug Fixes
 
-- Fixed a bug where applying a Maya preset to a muscle deformer triggered an unintended recomputation of the fibers flow upon scene open when the source muscle, from which the preset was saved, had a differing vertex count. *AdonisFX-1652*
+- Fixed a bug where applying a Maya preset to a muscle deformer triggered an unintended recomputation of the fibers flow upon scene open when the source muscle, from which the preset was saved, had a differing vertex count. *Adonis-1652*
 
 ### Deprecated
 
@@ -252,9 +252,9 @@
 
 ### Known Limitations
 
-- Painting weight maps on AdnGlue are not supported if other deformers are applied to the AdnGlue output mesh directly. *AdonisFX-1644*
-- Maya Cached Playback can be used for simulation preview but in order to get the correct simulation results it is required to disable the Cached Playback. *AdonisFX-1624*
-- Features debugging in the viewport is not supported with Maya Cached Playback enabled. *AdonisFX-1600*
+- Painting weight maps on AdnGlue are not supported if other deformers are applied to the AdnGlue output mesh directly. *Adonis-1644*
+- Maya Cached Playback can be used for simulation preview but in order to get the correct simulation results it is required to disable the Cached Playback. *Adonis-1624*
+- Features debugging in the viewport is not supported with Maya Cached Playback enabled. *Adonis-1600*
 
 ## Version 1.4.1
 2024-12-09
@@ -288,37 +288,37 @@
 - Added support to Hard Constraints in AdnFat solver including paintable map and stiffness override.
 - Optimized AdnFat deformer.
 - Optimized AdnSkin deformer.
-- Optimized AdonisFX Paint Tool.
+- Optimized Adonis Paint Tool.
 - Added color interpolation to the fibers debugger in AdnMuscle and AdnRibbonMuscle to encode the muscle activation.
 - Deprecated AdnWeightsDisplayNode.
-- Added a shortcut in the AdonisFX menu to upgrade deprecated nodes.
+- Added a shortcut in the Adonis menu to upgrade deprecated nodes.
 - Added the ability to choose which constraints reinitialize at start time.
 
 
 ### Bug Fixes
 
-- Fixed the solvers at start time to first compute one simulation step and then reinitialize the system. *AdonisFX-1445*
-- Fixed a bug in the normalization of the paintable weights on initialization to dump the resulting weights. *AdonisFX-1438*
-- Fixed a bug that was preventing the debugger from working if there were any intermediate nodes between the AdonisFX deformer and the shape node. *AdonisFX-1478*
-- Fixed a Maya crash when reopening a scene that was saved with an AdonisFX deformer disabled. *AdonisFX-1483*
-- Fixed fiber’s direction initialization at start time. *AdonisFX-1499*
-- Fixed a bug in the Volume Constraint that was causing flickering if the simulated geometry was far from the center of the world. *AdonisFX-1489*
-- Fixed the internal bounding box construction at start time to use the current point positions instead of the point positions at rest. *AdonisFX-1511*
+- Fixed the solvers at start time to first compute one simulation step and then reinitialize the system. *Adonis-1445*
+- Fixed a bug in the normalization of the paintable weights on initialization to dump the resulting weights. *Adonis-1438*
+- Fixed a bug that was preventing the debugger from working if there were any intermediate nodes between the Adonis deformer and the shape node. *Adonis-1478*
+- Fixed a Maya crash when reopening a scene that was saved with an Adonis deformer disabled. *Adonis-1483*
+- Fixed fiber’s direction initialization at start time. *Adonis-1499*
+- Fixed a bug in the Volume Constraint that was causing flickering if the simulated geometry was far from the center of the world. *Adonis-1489*
+- Fixed the internal bounding box construction at start time to use the current point positions instead of the point positions at rest. *Adonis-1511*
 
 ### Deprecated
 
-- The AdnWeightsDisplayNode is deprecated. This deprecation is fully backward-compatible, ensuring that scenes created in earlier versions will work as expected in version 1.4.0. To safely remove deprecated nodes from your scenes, a utility is added in AdonisFX Menu > Utils > *Upgrade Deprecated Nodes*.
+- The AdnWeightsDisplayNode is deprecated. This deprecation is fully backward-compatible, ensuring that scenes created in earlier versions will work as expected in version 1.4.0. To safely remove deprecated nodes from your scenes, a utility is added in Adonis Menu > Utils > *Upgrade Deprecated Nodes*.
 
 ### Known Limitations
 
-- Undoing the removal of inputs in AdnGlue does not restore the previous painted weights. *AdonisFX-1523*
+- Undoing the removal of inputs in AdnGlue does not restore the previous painted weights. *Adonis-1523*
 
 ## Version 1.3.1
 2024-11-28
 
 ### Improvements
 
-- Improved the floating licensing setup to allow connection with both interactive and batch servers without the need of a switch in the environment configuration. This change is fully backward compatible. *AdonisFX-1384*
+- Improved the floating licensing setup to allow connection with both interactive and batch servers without the need of a switch in the environment configuration. This change is fully backward compatible. *Adonis-1384*
 
 ## Version 1.3.0
 2024-09-30
@@ -334,7 +334,7 @@
 
 - Added AdnFat deformer.
 - Added stiffness overrides per constraint type to all deformers.
-- Implemented dynamic loading of AdonisFX shelf and removed the `MAYA_SHELF_PATH` configuration from the module file.
+- Implemented dynamic loading of Adonis shelf and removed the `MAYA_SHELF_PATH` configuration from the module file.
 - Improved UX to prevent informative dialogs to prompt.
 - Improved UX to prevent dialogs to prompt when running commands from script.
 
@@ -345,8 +345,8 @@
 
 ### Known Limitations
 
-- Interaction muscle-to-muscle is not supported. *AdonisFX-1211*
-- Exporter and Importer do not support locators and sensors. *AdonisFX-1215*
+- Interaction muscle-to-muscle is not supported. *Adonis-1211*
+- Exporter and Importer do not support locators and sensors. *Adonis-1215*
 
 ## Version 1.2.0
 2024-08-05
@@ -362,35 +362,35 @@
 ### Maya
 
 - Added *Targets* array plug to AdnSkin deformer to connect multiple targets.
-- Added *Triangulate Mesh* option to all AdonisFX deformers to enable or disable the use of the triangulated version of the mesh for building the constraints.
+- Added *Triangulate Mesh* option to all Adonis deformers to enable or disable the use of the triangulated version of the mesh for building the constraints.
 - Added two new buttons to the shelf and two new entries in the menu to add and remove targets from an AdnSkin deformer.
 - Added support for debugging distance and fiber constraints.
 
 ### Known Limitations
 
-- Slide on geometry constraints in Fast mode are limited to simple setups. They need to run in Quality mode to ensure stability in complex scenarios. *AdonisFX-1213*
-- Volume ratio gain effect is dependent on the total volume of the muscle. This might require using volume ratios with a range different to the default [0, 2] if needed. *AdonisFX-1137*
-- Interaction muscle-to-muscle is not supported. *AdonisFX-1211*
-- Exporter and Importer do not support locators and sensors. *AdonisFX-1215*
-- Fat simulation is limited to the current features in AdnSkin solver. *AdonisFX-879*
+- Slide on geometry constraints in Fast mode are limited to simple setups. They need to run in Quality mode to ensure stability in complex scenarios. *Adonis-1213*
+- Volume ratio gain effect is dependent on the total volume of the muscle. This might require using volume ratios with a range different to the default [0, 2] if needed. *Adonis-1137*
+- Interaction muscle-to-muscle is not supported. *Adonis-1211*
+- Exporter and Importer do not support locators and sensors. *Adonis-1215*
+- Fat simulation is limited to the current features in AdnSkin solver. *Adonis-879*
 
 ## Version 1.1.2
 2024-07-23
 
 ### Bug Fixes
 
-- Fixed a bug in the Slide Collision Constraints that was overcorrecting in case of intersection with the collider with a magnitude greater than the collision threshold. *AdonisFX-1258*
+- Fixed a bug in the Slide Collision Constraints that was overcorrecting in case of intersection with the collider with a magnitude greater than the collision threshold. *Adonis-1258*
 
 ## Version 1.1.1
 2024-07-04
 
 ### Bug Fixes
 
-- Fixed a bug in how gravity was evaluated. Now the value from the UI represented in m/s<sup>2</sup> is converted to cm/s<sup>2</sup>. *AdonisFX-1250*
+- Fixed a bug in how gravity was evaluated. Now the value from the UI represented in m/s<sup>2</sup> is converted to cm/s<sup>2</sup>. *Adonis-1250*
 
 ### Considerations for backward compatibility
 
-- Due to the fix introduced in this version, in order to have the scenes created with previous versions work the same way, it is needed to set the gravity value in all AdonisFX nodes divided by 100. For example, if the AdonisFX setup in v1.1.0 (or older) used a gravity of 980, now this attribute needs to be changed to 9.8. If the setup did not use gravity, no adjustment needs to be done.
+- Due to the fix introduced in this version, in order to have the scenes created with previous versions work the same way, it is needed to set the gravity value in all Adonis nodes divided by 100. For example, if the Adonis setup in v1.1.0 (or older) used a gravity of 980, now this attribute needs to be changed to 9.8. If the setup did not use gravity, no adjustment needs to be done.
 
 ## Version 1.1.0
 2024-06-17
@@ -415,74 +415,74 @@
 - Added a sanity check to *Max Sliding Distance* attribute to warn the user if the input value is too high for the given target mesh.
 - Updated debugger system to visualize attachment to geometry constraints, slide on geometry constraints, shape preservation constraints and sliding surface.
 - Extended Importer and Exporter tools to support AdnSkinMerge deformer and new constraints (attachment to geometry and slide on geometry).
-- Added *Refresh Debugger* utility to the AdonisFX menu to create missing debug nodes and connections.
+- Added *Refresh Debugger* utility to the Adonis menu to create missing debug nodes and connections.
 - Allow source nodes of any type in the *Sensors Connection Editor*.
-- Extended AdonisFX menu with *Documentation*, *Tutorials* and *About* sections.
+- Extended Adonis menu with *Documentation*, *Tutorials* and *About* sections.
 
 ### Bug Fixes
 
-- Fixed AdonisFX Paint Tool initialization of simulated nodes with intermediate nodes. *AdonisFX-1184*
-- Fixed a bug that caused sliding constraints to not find valid triangles to slide on if the initial closest point on the target lies on an edge. *AdonisFX-1165*
-- Fixed importer to support sparse array maps. *AdonisFX-1155*
-- Fixed manipulation of referenced nodes while using the AdonisFX paint tool. *AdonisFX-1147*
-- Fixed paint flood operation not normalizing the weights properly. *AdonisFX-1146*
-- Fixed error messages not displaying the proper status of the AdnSimshape collider connections. *AdonisFX-1034*
-- Filtered characters to get valid identifiers when creating nodes with a custom name in Linux. *AdonisFX-1033*
-- Prevent Exporter from generating the AAD file if there is no valid data to export. *AdonisFX-1032*
-- Fixed a bug that did not allow adding attachments on a muscle deformer created on referenced geometry. *AdonisFX-506*
+- Fixed Adonis Paint Tool initialization of simulated nodes with intermediate nodes. *Adonis-1184*
+- Fixed a bug that caused sliding constraints to not find valid triangles to slide on if the initial closest point on the target lies on an edge. *Adonis-1165*
+- Fixed importer to support sparse array maps. *Adonis-1155*
+- Fixed manipulation of referenced nodes while using the Adonis paint tool. *Adonis-1147*
+- Fixed paint flood operation not normalizing the weights properly. *Adonis-1146*
+- Fixed error messages not displaying the proper status of the AdnSimshape collider connections. *Adonis-1034*
+- Filtered characters to get valid identifiers when creating nodes with a custom name in Linux. *Adonis-1033*
+- Prevent Exporter from generating the AAD file if there is no valid data to export. *Adonis-1032*
+- Fixed a bug that did not allow adding attachments on a muscle deformer created on referenced geometry. *Adonis-506*
 
 ### Known Limitations
 
-- Slide on geometry constraints in Fast mode are limited to simple setups. They need to run in Quality mode to ensure stability in complex scenarios. *AdonisFX-1213*
-- Volume ratio gain effect is dependent on the total volume of the muscle. This might require using volume ratios with a range different to the default [0, 2] if needed. *AdonisFX-1137*
-- Interaction muscle-to-muscle is not supported. *AdonisFX-1211*
-- Exporter and Importer do not support locators and sensors. *AdonisFX-1215*
-- Fat simulation is limited to the current features in AdnSkin solver. *AdonisFX-879*
+- Slide on geometry constraints in Fast mode are limited to simple setups. They need to run in Quality mode to ensure stability in complex scenarios. *Adonis-1213*
+- Volume ratio gain effect is dependent on the total volume of the muscle. This might require using volume ratios with a range different to the default [0, 2] if needed. *Adonis-1137*
+- Interaction muscle-to-muscle is not supported. *Adonis-1211*
+- Exporter and Importer do not support locators and sensors. *Adonis-1215*
+- Fat simulation is limited to the current features in AdnSkin solver. *Adonis-879*
 
 ## Version 1.0.4
 2024-06-05
 
 ### Bug Fixes
 
-- Updated third party libraries to address a problem in the licensing system that raised the Server Error Code 28 and prevented the activation of the product. *AdonisFX-1182*
+- Updated third party libraries to address a problem in the licensing system that raised the Server Error Code 28 and prevented the activation of the product. *Adonis-1182*
 
 ## Version 1.0.3
 2024-05-16
 
 ### Bug Fixes
 
-- Fixed a bug that caused muscle simulation to fail in very specific scenarios due to a precision issue in the initialization of Slide On Segment constraints. *AdonisFX-1138*
+- Fixed a bug that caused muscle simulation to fail in very specific scenarios due to a precision issue in the initialization of Slide On Segment constraints. *Adonis-1138*
 
 ### Improvements
 
-- Improved the update of painted maps for Attachments and Slide On Segment constraints at initialization. *AdonisFX-1136*
+- Improved the update of painted maps for Attachments and Slide On Segment constraints at initialization. *Adonis-1136*
 
 ## Version 1.0.2
 2024-04-30
 
 ### Bug Fixes
 
-- Fixed a bug that was crashing Maya on startup if the plugin was configured to auto load during the trial period. *AdonisFX-1097*
-- Fixed the debugger system where the performance was limited in complex scenes with multiple deformers debugging information at the same time. *AdonisFX-1110*
+- Fixed a bug that was crashing Maya on startup if the plugin was configured to auto load during the trial period. *Adonis-1097*
+- Fixed the debugger system where the performance was limited in complex scenes with multiple deformers debugging information at the same time. *Adonis-1110*
 
 ### Improvements
 
-- Extended the licensing system to support Trial Extension requests. *AdonisFX-1108*
+- Extended the licensing system to support Trial Extension requests. *Adonis-1108*
 
 ## Version 1.0.1
 2024-04-17
 
 ### Bug Fixes
 
-- Fixed a bug that was making Maya freeze when creating an AdnSkin deformer with the playback cache enabled. *AdonisFX-1087*
-- Fixed a bug in the validation of floating licenses that was preventing loading the plugin without admin permissions. *AdonisFX-724*
-- Fixed a bug that was preventing the licensing system to locate the licensing configuration file properly in some cases. *AdonisFX-1072*
-- Fixed a bug in the AdnSimshape activations debugger to support DG evaluation mode. *AdonisFX-1026*
-- Fixed a bug in the importer tool where it was attempting to assign a string value to a matrix plug. *AdonisFX-1090*
-- Fixed the *Draw Fibers* and *Hide Fibers* shortcuts to be undoable and avoid affecting muscles that are debugging other features different to fibers. *AdonisFX-998*
-- Fixed the *Remove Attachments* and *Remove Slide On Segment Constraint* shortcuts to prevent the user to remove attachments and segments that are currently in use by the AdonisFX Paint Tool. *AdonisFX-999*
-- Fixed the AdnLocatorRotation to draw a valid angle shape if the three inputs (start, mid and end positions) are aligned. *AdonisFX-1000*
-- Fixed the importer tool to run a validation before creating a deformer whose minimum requirements can't be found in the scene. *AdonisFX-1001*
+- Fixed a bug that was making Maya freeze when creating an AdnSkin deformer with the playback cache enabled. *Adonis-1087*
+- Fixed a bug in the validation of floating licenses that was preventing loading the plugin without admin permissions. *Adonis-724*
+- Fixed a bug that was preventing the licensing system to locate the licensing configuration file properly in some cases. *Adonis-1072*
+- Fixed a bug in the AdnSimshape activations debugger to support DG evaluation mode. *Adonis-1026*
+- Fixed a bug in the importer tool where it was attempting to assign a string value to a matrix plug. *Adonis-1090*
+- Fixed the *Draw Fibers* and *Hide Fibers* shortcuts to be undoable and avoid affecting muscles that are debugging other features different to fibers. *Adonis-998*
+- Fixed the *Remove Attachments* and *Remove Slide On Segment Constraint* shortcuts to prevent the user to remove attachments and segments that are currently in use by the Adonis Paint Tool. *Adonis-999*
+- Fixed the AdnLocatorRotation to draw a valid angle shape if the three inputs (start, mid and end positions) are aligned. *Adonis-1000*
+- Fixed the importer tool to run a validation before creating a deformer whose minimum requirements can't be found in the scene. *Adonis-1001*
 
 
 ## Version 1.0.0
@@ -493,7 +493,7 @@
 - Solver for skin simulation.
 - Solver for volumetric and planar muscle simulation.
 - Solver for facial simulation.
-- Proprietary set of constraints integrated in AdonisFX solvers:
+- Proprietary set of constraints integrated in Adonis solvers:
     - Fibers contraction
     - Volume preservation
     - Attachments
@@ -506,7 +506,7 @@
 
 ### Maya
 
-- A deformers specialized for each AdonisFX solver:
+- A deformers specialized for each Adonis solver:
     - AdnSkin
     - AdnMuscle
     - AdnRibbonMuscle
@@ -515,19 +515,19 @@
 - Locators to visualize relative distances, angles, velocities and accelerations between transform nodes in the scene: AdnLocatorPosition, AdnLocatorDistance, AdnLocatorRotation.
 - Plain AdnLocator with a custom shape for visualization purposes.
 - AdnEdgeEvaluator: A node to compute the compression map of a deformed geometry.
-- AdnWeightsDisplayNode: A node to visualize the paintable maps while painting from the AdonisFX Paint Tool.
+- AdnWeightsDisplayNode: A node to visualize the paintable maps while painting from the Adonis Paint Tool.
 - AdnLearnMusclePatches: Command to execute the ML process for facial muscles generation.
 - Learn Muscle Patches Tool: An intuitive UI to configure and run the AdnLearnMusclePatches command.
-- Sensors Connection Editor: A simple UI to make connections easily from sensors and locators to AdonisFX deformers.
-- AdonisFX Paint Tool: Custom tool to manipulate the paintable maps of the AdonisFX deformers to ensure that the solvers receive valid distribution of weights.
+- Sensors Connection Editor: A simple UI to make connections easily from sensors and locators to Adonis deformers.
+- Adonis Paint Tool: Custom tool to manipulate the paintable maps of the Adonis deformers to ensure that the solvers receive valid distribution of weights.
 - A debugger system composed by an AdnData node and an AdnDebugLocator to visualize information internal to the solvers such as connections to attachments, fiber directions, etc.
 
 ### Known Limitations
 
-- The *Max Sliding Distance* parameters in AdnSkin and AdnSimshape are represented in scene units. The higher this value is, the more units in the space the sliding constraint allows a vertex to slide on. If the polygons of the target geometry to slide on are very little compared to that value, then the sliding constraint will be time and memory consuming. *AdonisFX-997*
-- The activations debugger in AdnSimshape is limited to the Parallel and Serial evaluation modes. *AdonisFX-1026*
-- The debugger system draws debug data independently to the visibility of the mesh. *AdonisFX-802*
-- Enabling and disabling fibers display from the AdonisFX menu does not restore the previous status of the debug settings of the affected deformers. *AdonisFX-998*
-- The AdonisFX Paint Tool does not refresh the painted maps if the attachments or the slide on segment constraints are removed while the tool is opened. Restarting the tool is needed. *AdonisFX-999*
-- The AdnLocatorRotation does not draw the angle shape if the three inputs (start, mid and end positions) are aligned, i.e. when the angle is 180 degrees. *AdonisFX-1000*
-- The Importer tool creates and configures the deformers assuming that all the required inputs exist in the scene. If any of those is not found (e.g. target mesh in AdnSkin), they have to be reassigned to an existing object manually. *AdonisFX-1001*
+- The *Max Sliding Distance* parameters in AdnSkin and AdnSimshape are represented in scene units. The higher this value is, the more units in the space the sliding constraint allows a vertex to slide on. If the polygons of the target geometry to slide on are very little compared to that value, then the sliding constraint will be time and memory consuming. *Adonis-997*
+- The activations debugger in AdnSimshape is limited to the Parallel and Serial evaluation modes. *Adonis-1026*
+- The debugger system draws debug data independently to the visibility of the mesh. *Adonis-802*
+- Enabling and disabling fibers display from the Adonis menu does not restore the previous status of the debug settings of the affected deformers. *Adonis-998*
+- The Adonis Paint Tool does not refresh the painted maps if the attachments or the slide on segment constraints are removed while the tool is opened. Restarting the tool is needed. *Adonis-999*
+- The AdnLocatorRotation does not draw the angle shape if the three inputs (start, mid and end positions) are aligned, i.e. when the angle is 180 degrees. *Adonis-1000*
+- The Importer tool creates and configures the deformers assuming that all the required inputs exist in the scene. If any of those is not found (e.g. target mesh in AdnSkin), they have to be reassigned to an existing object manually. *Adonis-1001*

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,7 @@
 2026-06-02
 
 ### Bug Fixes
-- Fixed a bug that was causing subframe evaluations to default to one frame timestep instead of the evaluated subframe timestep. *Adonis-3193*.
+- Fixed a bug that was causing subframe evaluations to default to one frame timestep instead of the evaluated subframe timestep. *AdonisFX-3193*.
 
 ## Version 2.0.0
 2026-03-04
@@ -31,7 +31,7 @@
 - Integrated art-directable shapes for muscle deformers.
 - Implemented substepping for AdnSimshape and muscle deformers.
 - Implemented *Update v1.x to v2.x* menu utility.
-- Added *Visualization Modes* to the Adonis Paint Tool, allowing *Greyscale* and *Heat Map* modes.
+- Added *Visualization Modes* to the AdonisFX Paint Tool, allowing *Greyscale* and *Heat Map* modes.
 - Added *Update on Topology Change* attribute for AdnPush and AdnRelax.
 - Modified default attribute values in most of the nodes.
 - Reordered shelf and menu items.
@@ -56,8 +56,8 @@
 
 - Implemented new nodes for the muscle fiber workflow, including: AdnFiberProjection, AdnFiberDiffusion, and AdnFiberGroom.
 - Implemented an experimental API.
-- Implemented the *Make Paintable* menu utility to simplify the process of painting maps for an Adonis solver.
-- Implemented the *Make Groomable* menu utility to simplify the setup of fiber directions for an Adonis muscle solver.
+- Implemented the *Make Paintable* menu utility to simplify the process of painting maps for an AdonisFX solver.
+- Implemented the *Make Groomable* menu utility to simplify the setup of fiber directions for an AdonisFX muscle solver.
 - Implemented the *Separate Geometries* menu utility to split geometry pieces based on a primitive attribute using blast nodes.
 - Implemented the *Create Muscle PieceID* menu utility to create a primitive attribute that identifies each geometry piece using a connectivity node.
 
@@ -68,7 +68,7 @@
 - Improved experimental API in Maya.
 - Added support for the new features in the *Importer* and *Exporter* tools.
 - Improved the Mirror Tool in Maya to support left and right tokens in the middle of names (e.g. \_L\_ and \_R\_).
-- Improved the Connection Editor in Maya to restrict connections to Adonis locators (source) and Adonis muscles (destination).
+- Improved the Connection Editor in Maya to restrict connections to AdonisFX locators (source) and AdonisFX muscles (destination).
 - Added support for multiple AdnRelax and AdnPush nodes on the same geometry in Maya.
 - Added support in the experimental API for rebuilding the rig using the correct execution order in Maya and Houdini.
 - Added currentTime attribute to AdnSkinMerge in Maya for correct dependency graph evaluation.
@@ -78,14 +78,14 @@
 - Removed AdnWeightsDisplayNode that was deprecated in version 1.4.0.
 
 ### Known Limitations
-- AdnGlue SOP node's debugger in Houdini does not display lines correctly after scene reopen. *Adonis-2870*
-- Maya 2026 producing undesired behaviors on scene open on a fully configured Adonis scene with hidden geometries and GPU Override enabled. *Adonis-2760*
+- AdnGlue SOP node's debugger in Houdini does not display lines correctly after scene reopen. *AdonisFX-2870*
+- Maya 2026 producing undesired behaviors on scene open on a fully configured AdonisFX scene with hidden geometries and GPU Override enabled. *AdonisFX-2760*
 
 ## Version 1.7.3
 2025-10-22
 
 ### Bug Fixes
-- Resolved an issue that caused the custom paint context to fail in Maya 2026. *Adonis-2419*
+- Resolved an issue that caused the custom paint context to fail in Maya 2026. *AdonisFX-2419*
 
 ## Version 1.7.2
 2025-06-12
@@ -95,13 +95,13 @@
 - Improved material switch in the Paint Tool to support multiple materials on the same paintable geometry.
 
 ### Bug Fixes
-- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *Adonis-2111*
+- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *AdonisFX-2111*
 
 ## Version 1.7.1
 2025-06-09
 
 ### Improvements
-- Improved logger to display more information in batch mode. *Adonis-2100*
+- Improved logger to display more information in batch mode. *AdonisFX-2100*
 
 ## Version 1.7.0
 2025-05-28
@@ -115,7 +115,7 @@
 - Added volume preservation to the AdnGlue solver.
 
 ### Maya
-- Added an AdnTurbo script to build the whole Adonis rig from Python.
+- Added an AdnTurbo script to build the whole AdonisFX rig from Python.
 - Implemented a UI to execute AdnTurbo.
 - Added dynamic attributes to the AdnGlue node (e.g. substeps, gravity, soft constraints, attenuation, damping).
 - Added volume preservation attribute to the AdnGlue node.
@@ -132,7 +132,7 @@
 - Improved AdnActivation node support in the Experimental API to support value plugs without connections.
 
 ### Bug Fixes
-- Fixed a bug that was preventing skipping the computation of the slide collision constraints when the Compute Collisions checkbox was disabled in AdnSimshape. *Adonis-2043*
+- Fixed a bug that was preventing skipping the computation of the slide collision constraints when the Compute Collisions checkbox was disabled in AdnSimshape. *AdonisFX-2043*
 
 ### Deprecated
 - Removed Python code (UI, tools and utils) that was supporting the outdated Import and Export tools deprecated in 1.5.0.
@@ -145,13 +145,13 @@
 - Improved material switch in the Paint Tool to support multiple materials on the same paintable geometry.
 
 ### Bug Fixes
-- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *Adonis-2111*
+- Fixed a bug that was preventing the muscle solver from initializing if the input geometry had disconnected primitives. *AdonisFX-2111*
 
 ## Version 1.6.3
 2025-06-06
 
 ### Improvements
-- Improved logger to display more information in batch mode. *Adonis-2100*
+- Improved logger to display more information in batch mode. *AdonisFX-2100*
 
 ## Version 1.6.2
 2025-04-25
@@ -208,8 +208,8 @@
 - Updated menu with new items: *Mirror*, *Export (beta)*, *Import (beta)* and *Clear*.
 - Updated locator creator utils to use input matrix plugs and remapping functionalities in sensors.
 - Updated sensor creator utils to use input matrix plugs and remapping functionalities in sensors.
-- Improved Adonis logger to display messages on idle.
-- Displayed warning log when both the Adonis debugger and the Maya Cached Playback are enabled.
+- Improved AdonisFX logger to display messages on idle.
+- Displayed warning log when both the AdonisFX debugger and the Maya Cached Playback are enabled.
 
 ### Bug Fixes
 - Fixed *Refresh Debugger* utility to support namespaces.
@@ -244,7 +244,7 @@
 
 ### Bug Fixes
 
-- Fixed a bug where applying a Maya preset to a muscle deformer triggered an unintended recomputation of the fibers flow upon scene open when the source muscle, from which the preset was saved, had a differing vertex count. *Adonis-1652*
+- Fixed a bug where applying a Maya preset to a muscle deformer triggered an unintended recomputation of the fibers flow upon scene open when the source muscle, from which the preset was saved, had a differing vertex count. *AdonisFX-1652*
 
 ### Deprecated
 
@@ -252,9 +252,9 @@
 
 ### Known Limitations
 
-- Painting weight maps on AdnGlue are not supported if other deformers are applied to the AdnGlue output mesh directly. *Adonis-1644*
-- Maya Cached Playback can be used for simulation preview but in order to get the correct simulation results it is required to disable the Cached Playback. *Adonis-1624*
-- Features debugging in the viewport is not supported with Maya Cached Playback enabled. *Adonis-1600*
+- Painting weight maps on AdnGlue are not supported if other deformers are applied to the AdnGlue output mesh directly. *AdonisFX-1644*
+- Maya Cached Playback can be used for simulation preview but in order to get the correct simulation results it is required to disable the Cached Playback. *AdonisFX-1624*
+- Features debugging in the viewport is not supported with Maya Cached Playback enabled. *AdonisFX-1600*
 
 ## Version 1.4.1
 2024-12-09
@@ -288,37 +288,37 @@
 - Added support to Hard Constraints in AdnFat solver including paintable map and stiffness override.
 - Optimized AdnFat deformer.
 - Optimized AdnSkin deformer.
-- Optimized Adonis Paint Tool.
+- Optimized AdonisFX Paint Tool.
 - Added color interpolation to the fibers debugger in AdnMuscle and AdnRibbonMuscle to encode the muscle activation.
 - Deprecated AdnWeightsDisplayNode.
-- Added a shortcut in the Adonis menu to upgrade deprecated nodes.
+- Added a shortcut in the AdonisFX menu to upgrade deprecated nodes.
 - Added the ability to choose which constraints reinitialize at start time.
 
 
 ### Bug Fixes
 
-- Fixed the solvers at start time to first compute one simulation step and then reinitialize the system. *Adonis-1445*
-- Fixed a bug in the normalization of the paintable weights on initialization to dump the resulting weights. *Adonis-1438*
-- Fixed a bug that was preventing the debugger from working if there were any intermediate nodes between the Adonis deformer and the shape node. *Adonis-1478*
-- Fixed a Maya crash when reopening a scene that was saved with an Adonis deformer disabled. *Adonis-1483*
-- Fixed fiber’s direction initialization at start time. *Adonis-1499*
-- Fixed a bug in the Volume Constraint that was causing flickering if the simulated geometry was far from the center of the world. *Adonis-1489*
-- Fixed the internal bounding box construction at start time to use the current point positions instead of the point positions at rest. *Adonis-1511*
+- Fixed the solvers at start time to first compute one simulation step and then reinitialize the system. *AdonisFX-1445*
+- Fixed a bug in the normalization of the paintable weights on initialization to dump the resulting weights. *AdonisFX-1438*
+- Fixed a bug that was preventing the debugger from working if there were any intermediate nodes between the AdonisFX deformer and the shape node. *AdonisFX-1478*
+- Fixed a Maya crash when reopening a scene that was saved with an AdonisFX deformer disabled. *AdonisFX-1483*
+- Fixed fiber’s direction initialization at start time. *AdonisFX-1499*
+- Fixed a bug in the Volume Constraint that was causing flickering if the simulated geometry was far from the center of the world. *AdonisFX-1489*
+- Fixed the internal bounding box construction at start time to use the current point positions instead of the point positions at rest. *AdonisFX-1511*
 
 ### Deprecated
 
-- The AdnWeightsDisplayNode is deprecated. This deprecation is fully backward-compatible, ensuring that scenes created in earlier versions will work as expected in version 1.4.0. To safely remove deprecated nodes from your scenes, a utility is added in Adonis Menu > Utils > *Upgrade Deprecated Nodes*.
+- The AdnWeightsDisplayNode is deprecated. This deprecation is fully backward-compatible, ensuring that scenes created in earlier versions will work as expected in version 1.4.0. To safely remove deprecated nodes from your scenes, a utility is added in AdonisFX Menu > Utils > *Upgrade Deprecated Nodes*.
 
 ### Known Limitations
 
-- Undoing the removal of inputs in AdnGlue does not restore the previous painted weights. *Adonis-1523*
+- Undoing the removal of inputs in AdnGlue does not restore the previous painted weights. *AdonisFX-1523*
 
 ## Version 1.3.1
 2024-11-28
 
 ### Improvements
 
-- Improved the floating licensing setup to allow connection with both interactive and batch servers without the need of a switch in the environment configuration. This change is fully backward compatible. *Adonis-1384*
+- Improved the floating licensing setup to allow connection with both interactive and batch servers without the need of a switch in the environment configuration. This change is fully backward compatible. *AdonisFX-1384*
 
 ## Version 1.3.0
 2024-09-30
@@ -334,7 +334,7 @@
 
 - Added AdnFat deformer.
 - Added stiffness overrides per constraint type to all deformers.
-- Implemented dynamic loading of Adonis shelf and removed the `MAYA_SHELF_PATH` configuration from the module file.
+- Implemented dynamic loading of AdonisFX shelf and removed the `MAYA_SHELF_PATH` configuration from the module file.
 - Improved UX to prevent informative dialogs to prompt.
 - Improved UX to prevent dialogs to prompt when running commands from script.
 
@@ -345,8 +345,8 @@
 
 ### Known Limitations
 
-- Interaction muscle-to-muscle is not supported. *Adonis-1211*
-- Exporter and Importer do not support locators and sensors. *Adonis-1215*
+- Interaction muscle-to-muscle is not supported. *AdonisFX-1211*
+- Exporter and Importer do not support locators and sensors. *AdonisFX-1215*
 
 ## Version 1.2.0
 2024-08-05
@@ -362,35 +362,35 @@
 ### Maya
 
 - Added *Targets* array plug to AdnSkin deformer to connect multiple targets.
-- Added *Triangulate Mesh* option to all Adonis deformers to enable or disable the use of the triangulated version of the mesh for building the constraints.
+- Added *Triangulate Mesh* option to all AdonisFX deformers to enable or disable the use of the triangulated version of the mesh for building the constraints.
 - Added two new buttons to the shelf and two new entries in the menu to add and remove targets from an AdnSkin deformer.
 - Added support for debugging distance and fiber constraints.
 
 ### Known Limitations
 
-- Slide on geometry constraints in Fast mode are limited to simple setups. They need to run in Quality mode to ensure stability in complex scenarios. *Adonis-1213*
-- Volume ratio gain effect is dependent on the total volume of the muscle. This might require using volume ratios with a range different to the default [0, 2] if needed. *Adonis-1137*
-- Interaction muscle-to-muscle is not supported. *Adonis-1211*
-- Exporter and Importer do not support locators and sensors. *Adonis-1215*
-- Fat simulation is limited to the current features in AdnSkin solver. *Adonis-879*
+- Slide on geometry constraints in Fast mode are limited to simple setups. They need to run in Quality mode to ensure stability in complex scenarios. *AdonisFX-1213*
+- Volume ratio gain effect is dependent on the total volume of the muscle. This might require using volume ratios with a range different to the default [0, 2] if needed. *AdonisFX-1137*
+- Interaction muscle-to-muscle is not supported. *AdonisFX-1211*
+- Exporter and Importer do not support locators and sensors. *AdonisFX-1215*
+- Fat simulation is limited to the current features in AdnSkin solver. *AdonisFX-879*
 
 ## Version 1.1.2
 2024-07-23
 
 ### Bug Fixes
 
-- Fixed a bug in the Slide Collision Constraints that was overcorrecting in case of intersection with the collider with a magnitude greater than the collision threshold. *Adonis-1258*
+- Fixed a bug in the Slide Collision Constraints that was overcorrecting in case of intersection with the collider with a magnitude greater than the collision threshold. *AdonisFX-1258*
 
 ## Version 1.1.1
 2024-07-04
 
 ### Bug Fixes
 
-- Fixed a bug in how gravity was evaluated. Now the value from the UI represented in m/s<sup>2</sup> is converted to cm/s<sup>2</sup>. *Adonis-1250*
+- Fixed a bug in how gravity was evaluated. Now the value from the UI represented in m/s<sup>2</sup> is converted to cm/s<sup>2</sup>. *AdonisFX-1250*
 
 ### Considerations for backward compatibility
 
-- Due to the fix introduced in this version, in order to have the scenes created with previous versions work the same way, it is needed to set the gravity value in all Adonis nodes divided by 100. For example, if the Adonis setup in v1.1.0 (or older) used a gravity of 980, now this attribute needs to be changed to 9.8. If the setup did not use gravity, no adjustment needs to be done.
+- Due to the fix introduced in this version, in order to have the scenes created with previous versions work the same way, it is needed to set the gravity value in all AdonisFX nodes divided by 100. For example, if the AdonisFX setup in v1.1.0 (or older) used a gravity of 980, now this attribute needs to be changed to 9.8. If the setup did not use gravity, no adjustment needs to be done.
 
 ## Version 1.1.0
 2024-06-17
@@ -415,74 +415,74 @@
 - Added a sanity check to *Max Sliding Distance* attribute to warn the user if the input value is too high for the given target mesh.
 - Updated debugger system to visualize attachment to geometry constraints, slide on geometry constraints, shape preservation constraints and sliding surface.
 - Extended Importer and Exporter tools to support AdnSkinMerge deformer and new constraints (attachment to geometry and slide on geometry).
-- Added *Refresh Debugger* utility to the Adonis menu to create missing debug nodes and connections.
+- Added *Refresh Debugger* utility to the AdonisFX menu to create missing debug nodes and connections.
 - Allow source nodes of any type in the *Sensors Connection Editor*.
-- Extended Adonis menu with *Documentation*, *Tutorials* and *About* sections.
+- Extended AdonisFX menu with *Documentation*, *Tutorials* and *About* sections.
 
 ### Bug Fixes
 
-- Fixed Adonis Paint Tool initialization of simulated nodes with intermediate nodes. *Adonis-1184*
-- Fixed a bug that caused sliding constraints to not find valid triangles to slide on if the initial closest point on the target lies on an edge. *Adonis-1165*
-- Fixed importer to support sparse array maps. *Adonis-1155*
-- Fixed manipulation of referenced nodes while using the Adonis paint tool. *Adonis-1147*
-- Fixed paint flood operation not normalizing the weights properly. *Adonis-1146*
-- Fixed error messages not displaying the proper status of the AdnSimshape collider connections. *Adonis-1034*
-- Filtered characters to get valid identifiers when creating nodes with a custom name in Linux. *Adonis-1033*
-- Prevent Exporter from generating the AAD file if there is no valid data to export. *Adonis-1032*
-- Fixed a bug that did not allow adding attachments on a muscle deformer created on referenced geometry. *Adonis-506*
+- Fixed AdonisFX Paint Tool initialization of simulated nodes with intermediate nodes. *AdonisFX-1184*
+- Fixed a bug that caused sliding constraints to not find valid triangles to slide on if the initial closest point on the target lies on an edge. *AdonisFX-1165*
+- Fixed importer to support sparse array maps. *AdonisFX-1155*
+- Fixed manipulation of referenced nodes while using the AdonisFX paint tool. *AdonisFX-1147*
+- Fixed paint flood operation not normalizing the weights properly. *AdonisFX-1146*
+- Fixed error messages not displaying the proper status of the AdnSimshape collider connections. *AdonisFX-1034*
+- Filtered characters to get valid identifiers when creating nodes with a custom name in Linux. *AdonisFX-1033*
+- Prevent Exporter from generating the AAD file if there is no valid data to export. *AdonisFX-1032*
+- Fixed a bug that did not allow adding attachments on a muscle deformer created on referenced geometry. *AdonisFX-506*
 
 ### Known Limitations
 
-- Slide on geometry constraints in Fast mode are limited to simple setups. They need to run in Quality mode to ensure stability in complex scenarios. *Adonis-1213*
-- Volume ratio gain effect is dependent on the total volume of the muscle. This might require using volume ratios with a range different to the default [0, 2] if needed. *Adonis-1137*
-- Interaction muscle-to-muscle is not supported. *Adonis-1211*
-- Exporter and Importer do not support locators and sensors. *Adonis-1215*
-- Fat simulation is limited to the current features in AdnSkin solver. *Adonis-879*
+- Slide on geometry constraints in Fast mode are limited to simple setups. They need to run in Quality mode to ensure stability in complex scenarios. *AdonisFX-1213*
+- Volume ratio gain effect is dependent on the total volume of the muscle. This might require using volume ratios with a range different to the default [0, 2] if needed. *AdonisFX-1137*
+- Interaction muscle-to-muscle is not supported. *AdonisFX-1211*
+- Exporter and Importer do not support locators and sensors. *AdonisFX-1215*
+- Fat simulation is limited to the current features in AdnSkin solver. *AdonisFX-879*
 
 ## Version 1.0.4
 2024-06-05
 
 ### Bug Fixes
 
-- Updated third party libraries to address a problem in the licensing system that raised the Server Error Code 28 and prevented the activation of the product. *Adonis-1182*
+- Updated third party libraries to address a problem in the licensing system that raised the Server Error Code 28 and prevented the activation of the product. *AdonisFX-1182*
 
 ## Version 1.0.3
 2024-05-16
 
 ### Bug Fixes
 
-- Fixed a bug that caused muscle simulation to fail in very specific scenarios due to a precision issue in the initialization of Slide On Segment constraints. *Adonis-1138*
+- Fixed a bug that caused muscle simulation to fail in very specific scenarios due to a precision issue in the initialization of Slide On Segment constraints. *AdonisFX-1138*
 
 ### Improvements
 
-- Improved the update of painted maps for Attachments and Slide On Segment constraints at initialization. *Adonis-1136*
+- Improved the update of painted maps for Attachments and Slide On Segment constraints at initialization. *AdonisFX-1136*
 
 ## Version 1.0.2
 2024-04-30
 
 ### Bug Fixes
 
-- Fixed a bug that was crashing Maya on startup if the plugin was configured to auto load during the trial period. *Adonis-1097*
-- Fixed the debugger system where the performance was limited in complex scenes with multiple deformers debugging information at the same time. *Adonis-1110*
+- Fixed a bug that was crashing Maya on startup if the plugin was configured to auto load during the trial period. *AdonisFX-1097*
+- Fixed the debugger system where the performance was limited in complex scenes with multiple deformers debugging information at the same time. *AdonisFX-1110*
 
 ### Improvements
 
-- Extended the licensing system to support Trial Extension requests. *Adonis-1108*
+- Extended the licensing system to support Trial Extension requests. *AdonisFX-1108*
 
 ## Version 1.0.1
 2024-04-17
 
 ### Bug Fixes
 
-- Fixed a bug that was making Maya freeze when creating an AdnSkin deformer with the playback cache enabled. *Adonis-1087*
-- Fixed a bug in the validation of floating licenses that was preventing loading the plugin without admin permissions. *Adonis-724*
-- Fixed a bug that was preventing the licensing system to locate the licensing configuration file properly in some cases. *Adonis-1072*
-- Fixed a bug in the AdnSimshape activations debugger to support DG evaluation mode. *Adonis-1026*
-- Fixed a bug in the importer tool where it was attempting to assign a string value to a matrix plug. *Adonis-1090*
-- Fixed the *Draw Fibers* and *Hide Fibers* shortcuts to be undoable and avoid affecting muscles that are debugging other features different to fibers. *Adonis-998*
-- Fixed the *Remove Attachments* and *Remove Slide On Segment Constraint* shortcuts to prevent the user to remove attachments and segments that are currently in use by the Adonis Paint Tool. *Adonis-999*
-- Fixed the AdnLocatorRotation to draw a valid angle shape if the three inputs (start, mid and end positions) are aligned. *Adonis-1000*
-- Fixed the importer tool to run a validation before creating a deformer whose minimum requirements can't be found in the scene. *Adonis-1001*
+- Fixed a bug that was making Maya freeze when creating an AdnSkin deformer with the playback cache enabled. *AdonisFX-1087*
+- Fixed a bug in the validation of floating licenses that was preventing loading the plugin without admin permissions. *AdonisFX-724*
+- Fixed a bug that was preventing the licensing system to locate the licensing configuration file properly in some cases. *AdonisFX-1072*
+- Fixed a bug in the AdnSimshape activations debugger to support DG evaluation mode. *AdonisFX-1026*
+- Fixed a bug in the importer tool where it was attempting to assign a string value to a matrix plug. *AdonisFX-1090*
+- Fixed the *Draw Fibers* and *Hide Fibers* shortcuts to be undoable and avoid affecting muscles that are debugging other features different to fibers. *AdonisFX-998*
+- Fixed the *Remove Attachments* and *Remove Slide On Segment Constraint* shortcuts to prevent the user to remove attachments and segments that are currently in use by the AdonisFX Paint Tool. *AdonisFX-999*
+- Fixed the AdnLocatorRotation to draw a valid angle shape if the three inputs (start, mid and end positions) are aligned. *AdonisFX-1000*
+- Fixed the importer tool to run a validation before creating a deformer whose minimum requirements can't be found in the scene. *AdonisFX-1001*
 
 
 ## Version 1.0.0
@@ -493,7 +493,7 @@
 - Solver for skin simulation.
 - Solver for volumetric and planar muscle simulation.
 - Solver for facial simulation.
-- Proprietary set of constraints integrated in Adonis solvers:
+- Proprietary set of constraints integrated in AdonisFX solvers:
     - Fibers contraction
     - Volume preservation
     - Attachments
@@ -506,7 +506,7 @@
 
 ### Maya
 
-- A deformers specialized for each Adonis solver:
+- A deformers specialized for each AdonisFX solver:
     - AdnSkin
     - AdnMuscle
     - AdnRibbonMuscle
@@ -515,19 +515,19 @@
 - Locators to visualize relative distances, angles, velocities and accelerations between transform nodes in the scene: AdnLocatorPosition, AdnLocatorDistance, AdnLocatorRotation.
 - Plain AdnLocator with a custom shape for visualization purposes.
 - AdnEdgeEvaluator: A node to compute the compression map of a deformed geometry.
-- AdnWeightsDisplayNode: A node to visualize the paintable maps while painting from the Adonis Paint Tool.
+- AdnWeightsDisplayNode: A node to visualize the paintable maps while painting from the AdonisFX Paint Tool.
 - AdnLearnMusclePatches: Command to execute the ML process for facial muscles generation.
 - Learn Muscle Patches Tool: An intuitive UI to configure and run the AdnLearnMusclePatches command.
-- Sensors Connection Editor: A simple UI to make connections easily from sensors and locators to Adonis deformers.
-- Adonis Paint Tool: Custom tool to manipulate the paintable maps of the Adonis deformers to ensure that the solvers receive valid distribution of weights.
+- Sensors Connection Editor: A simple UI to make connections easily from sensors and locators to AdonisFX deformers.
+- AdonisFX Paint Tool: Custom tool to manipulate the paintable maps of the AdonisFX deformers to ensure that the solvers receive valid distribution of weights.
 - A debugger system composed by an AdnData node and an AdnDebugLocator to visualize information internal to the solvers such as connections to attachments, fiber directions, etc.
 
 ### Known Limitations
 
-- The *Max Sliding Distance* parameters in AdnSkin and AdnSimshape are represented in scene units. The higher this value is, the more units in the space the sliding constraint allows a vertex to slide on. If the polygons of the target geometry to slide on are very little compared to that value, then the sliding constraint will be time and memory consuming. *Adonis-997*
-- The activations debugger in AdnSimshape is limited to the Parallel and Serial evaluation modes. *Adonis-1026*
-- The debugger system draws debug data independently to the visibility of the mesh. *Adonis-802*
-- Enabling and disabling fibers display from the Adonis menu does not restore the previous status of the debug settings of the affected deformers. *Adonis-998*
-- The Adonis Paint Tool does not refresh the painted maps if the attachments or the slide on segment constraints are removed while the tool is opened. Restarting the tool is needed. *Adonis-999*
-- The AdnLocatorRotation does not draw the angle shape if the three inputs (start, mid and end positions) are aligned, i.e. when the angle is 180 degrees. *Adonis-1000*
-- The Importer tool creates and configures the deformers assuming that all the required inputs exist in the scene. If any of those is not found (e.g. target mesh in AdnSkin), they have to be reassigned to an existing object manually. *Adonis-1001*
+- The *Max Sliding Distance* parameters in AdnSkin and AdnSimshape are represented in scene units. The higher this value is, the more units in the space the sliding constraint allows a vertex to slide on. If the polygons of the target geometry to slide on are very little compared to that value, then the sliding constraint will be time and memory consuming. *AdonisFX-997*
+- The activations debugger in AdnSimshape is limited to the Parallel and Serial evaluation modes. *AdonisFX-1026*
+- The debugger system draws debug data independently to the visibility of the mesh. *AdonisFX-802*
+- Enabling and disabling fibers display from the AdonisFX menu does not restore the previous status of the debug settings of the affected deformers. *AdonisFX-998*
+- The AdonisFX Paint Tool does not refresh the painted maps if the attachments or the slide on segment constraints are removed while the tool is opened. Restarting the tool is needed. *AdonisFX-999*
+- The AdnLocatorRotation does not draw the angle shape if the three inputs (start, mid and end positions) are aligned, i.e. when the angle is 180 degrees. *AdonisFX-1000*
+- The Importer tool creates and configures the deformers assuming that all the required inputs exist in the scene. If any of those is not found (e.g. target mesh in AdnSkin), they have to be reassigned to an existing object manually. *AdonisFX-1001*

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,7 +2,7 @@
 
 ## Software
 
-- Maya 2023, 2024, 2025, 2026
+- Maya 2024, 2025, 2026, 2027
 - Houdini 20.0, 20.5, 21.0
 
 ## System Requirements

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -13,6 +13,6 @@
 - **Storage**: 16MB of free disk space to install.
 
 > [!NOTE]
-> - AdonisFX may work with other CPU and RAM specifications.
+> - Adonis may work with other CPU and RAM specifications.
 > - The list above represents the specifications that have been tested successfully.
 > - Internet connection is required for licensing only.

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -2,11 +2,11 @@
 
 ## Activation Node
 
-Activation Node or **AdnActivation** is an AdonisFX node that allows you to perform operations on input activation values to produce a final activation value that can be used to drive the activation of a muscle. This node allows you to override, add, subtract, multiply, divide, etc. multiple input activations to produce one single output. The input activations can be used by ingesting AdonisFX sensor data (AdnSensorPosition, AdnSensorDistance, AdnSensorRotation). This node is recommended to be used when on-demand activations are required or when multiple activations from several sensors have to be merged into one value.
+Activation Node or **AdnActivation** is an Adonis node that allows you to perform operations on input activation values to produce a final activation value that can be used to drive the activation of a muscle. This node allows you to override, add, subtract, multiply, divide, etc. multiple input activations to produce one single output. The input activations can be used by ingesting Adonis sensor data (AdnSensorPosition, AdnSensorDistance, AdnSensorRotation). This node is recommended to be used when on-demand activations are required or when multiple activations from several sensors have to be merged into one value.
 
 ## Constraints
 
-Constraints are rules that an AdonisFX solver applies during simulation to ensure that the relationship between elements involved in the simulation is maintained, such as distance between geometry points, distance between geometry points and external attachments, rig joints or external meshes, etc. The catalog of constraints is presented below.
+Constraints are rules that an Adonis solver applies during simulation to ensure that the relationship between elements involved in the simulation is maintained, such as distance between geometry points, distance between geometry points and external attachments, rig joints or external meshes, etc. The catalog of constraints is presented below.
 
 **Attachment To Transform**. An attachment to transform constraint defines the relationship between a geometry point and an external transform object. During simulation, an attachment constraint will try to keep the geometry point at a constant location relative to the transform.
 
@@ -20,7 +20,7 @@ Constraints are rules that an AdonisFX solver applies during simulation to ensur
 
 **Hard**. A hard constraint defines the location of a geometry point in the tangent space of a polygon. This constraint type is similar to the attachment constraint but in this case the transformation used is the one given by the tangent space at the closest point on an external geometry.
 
-**Self-Collision**. Applies corrections to the points that are intersecting with the geometry itself. There are two modes of self-collisions correction in AdonisFX: point-to-point and triangle-to-triangle. In point-to-point mode, an intersection occurs if the volume around a point intersects with the volume of another point. This volume can be a perfect sphere (uniform, defined by a radius) or a spheroid (when there is thickness and differs with the radius). In triangle-to-triangle mode, an intersection occurs if two triangles are intersecting each other, which can happen if one or two edges of one triangle cross the area of the other triangle.
+**Self-Collision**. Applies corrections to the points that are intersecting with the geometry itself. There are two modes of self-collisions correction in Adonis: point-to-point and triangle-to-triangle. In point-to-point mode, an intersection occurs if the volume around a point intersects with the volume of another point. This volume can be a perfect sphere (uniform, defined by a radius) or a spheroid (when there is thickness and differs with the radius). In triangle-to-triangle mode, an intersection occurs if two triangles are intersecting each other, which can happen if one or two edges of one triangle cross the area of the other triangle.
 
 **Shape Preservation**. A shape preservation constraint defines the state of the shape formed by a vertex with its adjacents on initialization. During simulation, a shape preservation constraint will try to maintain the rest shape of the geometry with its neighboring vertices.
 
@@ -42,27 +42,27 @@ Constraints are rules that an AdonisFX solver applies during simulation to ensur
 
 ## Fat
 
-Fat or **AdnFat** is an AdonisFX solver for fat simulation. This solver allows simulating a mesh surface as if it were a closed volume of fat tissue. The volume is constructed procedurally using two compatible geometries: a base mesh to drive the simulation (i.e. the fascia) and a destination mesh (i.e. the fat) on which to apply the simulation. Thanks to that internal volume structure, the solver is able to produce realistic dynamics typical of fat tissues.
+Fat or **AdnFat** is an Adonis solver for fat simulation. This solver allows simulating a mesh surface as if it were a closed volume of fat tissue. The volume is constructed procedurally using two compatible geometries: a base mesh to drive the simulation (i.e. the fascia) and a destination mesh (i.e. the fat) on which to apply the simulation. Thanks to that internal volume structure, the solver is able to produce realistic dynamics typical of fat tissues.
 
 ## Glue
 
-Glue or **AdnGlue** is an AdonisFX solver for gluing muscles together after simulation. This solver allows you to glue muscles together giving the simulation of the muscles layer a more compact look. The gluing is achieved by ingesting the muscles into the solver and generating one combined output mesh with Glue Constraints applied. Given a maximum glue distance the gluing can be modulated and controlled to reduce the gluing effect against unwanted muscles. Glue can be useful for improving the simulation of the fascia layer by creating a more compact version of the muscles layer avoiding big gaps.
+Glue or **AdnGlue** is an Adonis solver for gluing muscles together after simulation. This solver allows you to glue muscles together giving the simulation of the muscles layer a more compact look. The gluing is achieved by ingesting the muscles into the solver and generating one combined output mesh with Glue Constraints applied. Given a maximum glue distance the gluing can be modulated and controlled to reduce the gluing effect against unwanted muscles. Glue can be useful for improving the simulation of the fascia layer by creating a more compact version of the muscles layer avoiding big gaps.
 
 ## Locator
 
-Locators are intended to visualize the output of an AdonisFX sensor. There are three types of locators that require a specific number of inputs and adopt custom shapes in the viewport: AdnLocatorPosition (a squared box at the location of a node), AdnLocatorDistance (a parallelepiped with a line connecting two nodes) and AdnLocatorRotation (an angle with two segments connecting three nodes). Each type is associated with its homologous sensor.
+Locators are intended to visualize the output of an Adonis sensor. There are three types of locators that require a specific number of inputs and adopt custom shapes in the viewport: AdnLocatorPosition (a squared box at the location of a node), AdnLocatorDistance (a parallelepiped with a line connecting two nodes) and AdnLocatorRotation (an angle with two segments connecting three nodes). Each type is associated with its homologous sensor.
 
 ## Mummy
 
-The Mummy is a simplified, unified proxy that represents the overall body volume and serves as the foundation for deformation and simulation across the entire AdonisFX stack. It is typically built as a wrapped mesh around the individual bone geometries, which improves reliability when computing attachments and allows for stable sliding against target geometry, helping to avoid artifacts such as popping, creasing, and stretching. The mummy must generally be a single, continuous mesh with no separated or floating pieces, although it can optionally be split into multiple pieces when more control over attachment regions is required. Its vertex count should adapt to the proportions and complexity of the creature without introducing unnecessary density. The geometry must also be fully sealed and watertight, especially around critical areas like the rib cage and torso, while maintaining clean, optimized topology with minimal unnecessary subdivisions. For best results, it should be modeled at real-world scale to ensure consistent and reliable simulation behavior.
+The Mummy is a simplified, unified proxy that represents the overall body volume and serves as the foundation for deformation and simulation across the entire Adonis stack. It is typically built as a wrapped mesh around the individual bone geometries, which improves reliability when computing attachments and allows for stable sliding against target geometry, helping to avoid artifacts such as popping, creasing, and stretching. The mummy must generally be a single, continuous mesh with no separated or floating pieces, although it can optionally be split into multiple pieces when more control over attachment regions is required. Its vertex count should adapt to the proportions and complexity of the creature without introducing unnecessary density. The geometry must also be fully sealed and watertight, especially around critical areas like the rib cage and torso, while maintaining clean, optimized topology with minimal unnecessary subdivisions. For best results, it should be modeled at real-world scale to ensure consistent and reliable simulation behavior.
 
 ## Muscle
 
-**AdnMuscle** is an AdonisFX solver for muscle simulation including volume preservation. It allows applying dynamics such as fibers contraction and volume gain to a geometry.
+**AdnMuscle** is an Adonis solver for muscle simulation including volume preservation. It allows applying dynamics such as fibers contraction and volume gain to a geometry.
 
 ## Muscle anisotropy
 
-Muscle anisotropy refers to the property of muscle tissue that causes it to behave differently depending on the direction of the applied forces. In AdonisFX, this property affects the edge stiffness based on the alignment with the fiber flow:
+Muscle anisotropy refers to the property of muscle tissue that causes it to behave differently depending on the direction of the applied forces. In Adonis, this property affects the edge stiffness based on the alignment with the fiber flow:
 
 - Edges aligned with the fiber direction have stiffness equal to the object's overall stiffness.
 - Edges orthogonal to the fiber direction have reduced stiffness.
@@ -73,7 +73,7 @@ This behavior is modulated with the anisotropy parameter where a value of 0.0 (d
 
 A muscle patch is a group of connected geometry vertices that represent an internal muscle projected onto the skin. A muscle patch is not an actual modelled geometry. Muscle patches are used by AdnSimshape solver for facial simulation. The muscle patches of a facial geometry can be generated with the Learn Muscle Patches Tool which applies Machine Learning techniques to estimate the distribution of muscles based on the set of facial expressions that a facial rig can reproduce.
 
-**AdonisFX Muscle Patches File**. The AdonisFX Muscle Patches File is a proprietary file format that stores the distribution of muscle patches generated by the Learn Muscle Patches tool. The file extension is `amp`.
+**Adonis Muscle Patches File**. The Adonis Muscle Patches File is a proprietary file format that stores the distribution of muscle patches generated by the Learn Muscle Patches tool. The file extension is `amp`.
 
 ## Push
 
@@ -85,11 +85,11 @@ Relax or **AdnRelax** is a deformer designed to smooth creases and correct over-
 
 ## Remap
 
-In terms of functionality, **AdnRemap** nodes are typically used in AdonisFX rigs to remap the output of a sensor into a value that adjusts better to the range expected at the destination attribute of a solver, like the activation or the volume ratio gain of a muscle. In terms of workflow, these nodes aim to enhance the portability of the whole AdonisFX rig, including not only the input and output connections but also the configuration of the remap ramp attribute.
+In terms of functionality, **AdnRemap** nodes are typically used in Adonis rigs to remap the output of a sensor into a value that adjusts better to the range expected at the destination attribute of a solver, like the activation or the volume ratio gain of a muscle. In terms of workflow, these nodes aim to enhance the portability of the whole Adonis rig, including not only the input and output connections but also the configuration of the remap ramp attribute.
 
 ## Ribbon Muscle
 
-The ribbon muscle or **AdnRibbonMuscle** is an AdonisFX solver for muscle simulation. It allows applying dynamics such as fibers contraction to a planar geometry.
+The ribbon muscle or **AdnRibbonMuscle** is an Adonis solver for muscle simulation. It allows applying dynamics such as fibers contraction to a planar geometry.
 
 ## Sensor
 
@@ -97,11 +97,11 @@ Sensors are nodes to measure positions, distances, angles, velocities and accele
 
 ## Simshape
 
-Simshape or **AdnSimshape** is an AdonisFX solver for facial simulation. It allows applying dynamics on top of the deformation driven by a facial rig. Also, it has the ability to mimic the change in rigidity of the skin due to the activation of the internal facial muscle patches.
+Simshape or **AdnSimshape** is an Adonis solver for facial simulation. It allows applying dynamics on top of the deformation driven by a facial rig. Also, it has the ability to mimic the change in rigidity of the skin due to the activation of the internal facial muscle patches.
 
 ## Skin
 
-Skin or **AdnSkin** is an AdonisFX solver for skin and fascia simulation. It allows applying dynamics to the skin of a character to produce realistic effects like wrinkles.
+Skin or **AdnSkin** is an Adonis solver for skin and fascia simulation. It allows applying dynamics to the skin of a character to produce realistic effects like wrinkles.
 
 ## Skin Merge
 


### PR DESCRIPTION
## [Preview](https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2Fdc12fffd0b3d9a613a030e42421cfeaf09cbf038%2Fdocs%2Findex.md)


## NOTE

These are the occurrences that I've not modified until getting confirmation:

<img width="731" height="541" alt="image" src="https://github.com/user-attachments/assets/bffa5bf1-e8ef-48a5-ac03-291ec34901c7" />

- I'm not sure if changing the occurrence in `mkdocs.yml` has any impact.
- The occurrence in `README.md` could be changed, but it refers to the name of the repo, so I would keep it.
- I'm keeping "adonisfx" in the links given that we don't know yet if they will change.
- I've not modified the occurrences related to `SaveServer.exe` in `licensing.md` given that the binary still shows "AdonisFX".

