### PR TITLE
#435 Pass to API docs for Maya and Houdini

### DIFF
--- a/docs/houdini/api.md
+++ b/docs/houdini/api.md
@@ -1,72 +1,222 @@
-# API
+# Houdini Python API
 
-### Experimental Python API
+## Experimental Python API
 
-> [!NOTE]
-> - This API is experimental, and will be subject to changes in following versions of Adonis.
-> - The use of this API in production applications is not supported.
+> [!WARNING]
+> This API is experimental and may change in future versions of Adonis.
+>
+> The use of this API in production applications is not supported.
 
-An experimental Python API has been developed to allow Technical Directors to implement custom Python scripts for exporting and rebuilding Adonis rigs programmatically.
+An experimental Python API is available for Technical Directors who need to implement custom Python scripts for exporting and rebuilding Adonis rigs programmatically.
 
 This API enables users to:
-- Extract the setup from an existing rig in Houdini.
+
+- Extract the setup from an existing Adonis rig in Houdini.
 - Rebuild the rig in another Houdini scene.
-- Export rig data in a format that could be imported into other DCCs (for example Maya).
+- Export rig data in a format that can be imported into other DCCs, for example Maya.
 
-As this API is still under active development, please do not hesitate to send an email to **adonis.support@inbibo.co.uk** to provide feedback and/or feature requests. The support and development teams will work together to incorporate user feedback and refine the implementation.
+As this API is still under active development, please send feedback and feature requests to **adonis.support@inbibo.co.uk**. The support and development teams will work together to incorporate user feedback and refine the implementation.
 
-The API can be found in `Adonis/python/adn/api/adnx.py`.
-The definitions can be imported with `from adn.api.adnx import *`.
+The API can be found in:
 
-Since the method definitions may change before the API becomes production-ready, here are some examples showing how to use the current experimental Python API for Houdini. Similar methods can be found directly in the `adnx.py` file.
+`Adonis/python/adn/api/adnx.py`
 
-1. How to create a rig instance with Houdini as the host: `rig = AdnRig(AdnHost.kHoudini)`.
-2. How to set the context in which the rig information will be gathered or created: `rig.setContext("/obj/geo1")`.
-3. How to create an Adonis rig component and add it to the rig (e.g. an AdnMuscle inside the rig): `muscle = AdnMuscle(rig)` and `rig.addSolver(muscle)`.
-4. How to gather data from an existing Adonis scene to populate the rig component entry (assuming AdnMuscle1 exists in the Houdini scene): `muscle.fromNode("AdnMuscle1")`.
-5. How to get the dictionary containing the extracted data: `data = muscle.getData()`.
-6. How to populate the rig component from a dictionary that contains all required entries: `muscle.fromDict(data)`. The required dictionary formatting can be found in the `__init__` methods of the `AdnMuscleBase` and `AdnMuscle` classes. Modifying dictionary entries allows users to update or rebuild rigs with custom values.
-7. How to update an existing rig component in the scene after modifying its values: `muscle.update()`. This method assumes that the target AdnMuscle already exists in the scene.
-8. How to build rig components in the scene: `muscle.build()` to build the muscle or `rig.build()` to build all the components.
-9. How to define the execution order when extracting data from an existing scene: `rig.buildExecutionOrder()`. With an already configured scene, this deduces the correct reconstruction order required to preserve deformation and node dependency chain.
-10. How to clear a specific rig component from the scene: `muscle.clear()`.
+The definitions can be imported with:
 
-All other methods can be found in the `Adonis/python/adn/api/adnx.py` file.
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.api.adnx import *
+</code></pre>
 
-The API is the base foundation for the Import/Export tools of Adonis. Below is an example of exported rig data in a .json file:
+The API exposes Adonis rig entities through Python classes and type identifiers. The available classes, supported data entries, and implementation details are defined directly in `adnx.py`.
+
+## Requirements
+
+Before using the Houdini Python API, the Houdini scene must follow the expected Adonis rig structure.
+
+A Houdini context must be defined with `rig.setContext("/obj/geo1")`. This tells the API which Geometry context should be used to extract or rebuild the rig.
+
+Rig components in Houdini must live directly inside the Geometry context. Encapsulating Adonis SOP nodes inside subnetworks is not supported.
+
+Each geometry to be deformed must be separated and encapsulated in a deformable region using two Null nodes prefixed with:
+
+- `ADN_IN_<geo_name>`
+- `ADN_OUT_<geo_name>`
+
+The `<geo_name>` value should match the expected shape name counterpart in Maya.
+
+The API uses these deformable region Null nodes to identify the geometry name associated with Adonis SOP nodes. When extracting data from Houdini, the API first looks for an `ADN_IN_` node upstream of the Adonis node, and can also use the corresponding `ADN_OUT_` node as a fallback.
+
+Nodes used to drive attachment to transform or slide on segment constraints, such as Null, joint, or rivet nodes, must live in the `/obj` context.
+
+To ease the process of separating geometries, use:
+
+**Adonis > Utils > Separate Geometries**
+
+This tool works when there is a valid piece attribute on the geometry stream, such as `path`, `name`, or `muscle_id`.
+
+## Basic Usage Examples
+
+The method definitions may change before the API becomes production-ready. The following examples show how to use the current experimental Python API for Houdini.
+
+### Create a Rig Instance
+
+Create a rig instance with Houdini as the host:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">rig = AdnRig(AdnHost.kHoudini)
+</code></pre>
+
+### Set the Houdini Context
+
+Set the context where rig information will be gathered or created:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">rig.setContext("/obj/geo1")
+</code></pre>
+
+The context must be a valid Houdini node.
+
+### Create a Rig Component
+
+Create an Adonis rig component and add it to the rig. For example, to create an **AdnMuscle** component:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle = AdnMuscle(rig)
+rig.addSolver(muscle)
+</code></pre>
+
+Some components are added automatically when they are created with a rig instance, depending on their base class. However, explicitly adding the component to the rig can help make the workflow clearer.
+
+### Extract Data from an Existing Node
+
+Gather data from an existing Adonis node in the Houdini scene.
+
+For example, if an **AdnMuscle** node named `AdnMuscle1` exists in the current Houdini context:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle.fromNode("AdnMuscle1")
+</code></pre>
+
+### Get Extracted Data
+
+Get the dictionary containing the extracted data:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">data = muscle.getData()
+</code></pre>
+
+The returned dictionary contains the component parameters, maps, connections, node information, and other data required to rebuild or update the component.
+
+### Populate a Component from a Dictionary
+
+Populate a rig component from a dictionary that contains all required entries:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle.fromDict(data)
+</code></pre>
+
+The required dictionary formatting can be found in the `__init__` methods of the corresponding classes, for example `AdnMuscleBase` and `AdnMuscle`.
+
+Modifying dictionary entries allows users to update or rebuild rigs with custom values.
+
+### Update an Existing Component
+
+Update an existing rig component in the scene after modifying its values:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle.update()
+</code></pre>
+
+This method assumes that the target Adonis node already exists in the Houdini scene.
+
+### Build Rig Components
+
+Build a single component in the scene:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle.build()
+</code></pre>
+
+Build all components registered in the rig:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">rig.build()
+</code></pre>
+
+### Define the Execution Order
+
+Define the execution order when extracting data from an existing scene:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">rig.buildExecutionOrder()
+</code></pre>
+
+With an already configured scene, this deduces the reconstruction order required to preserve deformation order and node dependency chains.
+
+The execution order is built from:
+
+1. Sensors.
+2. Non-deformable utility nodes.
+3. Deformers and solvers in deformation chain order.
+
+### Clear a Component
+
+Clear a specific rig component from the scene:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle.clear()
+</code></pre>
+
+In Houdini, clearing a node destroys the corresponding Houdini node. This operation is only expected to work when the network is not cooking.
+
+## Connections
+
+The API can extract and rebuild connections between Adonis nodes.
+
+In Houdini, connections are represented through parameter expressions. The API supports:
+
+- Detail attribute connections.
+- Channel reference connections.
+
+When extracting connections from Houdini, the API searches the evaluated node parameters and converts compatible expressions into serialized connection data.
+
+When rebuilding connections in Houdini, the API attempts to recreate those connections using the appropriate expression type.
+
+> [!NOTE]
+> Exported connections between Adonis nodes may differ depending on the DCC. This is expected due to differences between DCC applications. However, the rig should be reconstructed correctly when imported into any supported target DCC, as long as the required nodes, geometry, and rig structure are compatible.
+
+## Exported Rig Data
+
+The API is the foundation for the Import and Export tools in Adonis.
+
+Below is an example of exported rig data in a `.json` file:
 
 <figure markdown>
-  ![Houdini API Json example](images/houdini_api_json_example.png)
-  <figcaption><b>Figure 1</b>: Houdini API Json example.</figcaption>
+  ![Houdini API JSON example](images/houdini_api_json_example.png)
+  <figcaption><b>Figure 1</b>: Houdini API JSON example.</figcaption>
 </figure>
 
-Houdini rigs require some extra nodes to be added for API support. Below is an example network for an AdnMuscle rig component in Houdini.
+All other methods and data definitions can be found in:
 
-Each geometry to be deformed must be separated and encapsulated in a deformable region with two null nodes prefixed with:
+`Adonis/python/adn/api/adnx.py`
+
+## Houdini Network Structure
+
+Houdini rigs require extra nodes to be added for API support.
+
+Each geometry to be deformed must be separated and encapsulated in a deformable region with two Null nodes:
+
 - `ADN_IN_<geo_name>`
 - `ADN_OUT_<geo_name>`
 
 The `<geo_name>` should match the expected shape name counterpart in Maya.
 
-To ease the process of separating geometries, use the utility:
-- *Adonis* > *Utils* > *Separate Geometries*
-
-This tool works when there is a valid piece attribute (path, name, or muscle_id) on the geometry stream.
-
 <figure markdown>
-  ![Houdini muscle net example](images/muscle_net_example.png)
+  ![Houdini muscle network example](images/muscle_net_example.png)
   <figcaption><b>Figure 2</b>: Muscle network example with a deformable region.</figcaption>
 </figure>
 
-> [!NOTE]
-> - Deformed geometry uses the `Shape` suffix to describe the "geometry" entry. This is important when moving data between DCCs, as it must adhere to the naming convention.
-> - Data such as "geometryAttachments" are represented using the name without the `Shape` suffix. This is also important for interoperability between DCCs.
-> - A context must be defined in Houdini using the `rig.setContext("/obj/geo1")` method. This allows the API to know from which geometry context to extract data and where to reconstruct the rig.
-> - Rig components in Houdini must live directly inside the geometry node. Encapsulating components inside subnetworks (for example placing AdnMuscle nodes in a subnetwork) is not supported.
-> - Exported connections between Adonis nodes may differ depending on the DCC. This is expected due to differences between DCC applications. However, the rig will be correctly reconstructed when imported into any supported target DCC.
+## Naming and Interoperability
 
-### Limitations
+When transferring data between DCCs, some naming conventions must be respected.
 
-- The API does not support subnetworks inside of the Geometry context. This means that all Adonis SOP nodes (and any other SOP nodes containing geometry required by the Adonis rig) must exist at the same level within the Geometry context (e.g., */obj/geo1*).
-- Nodes used to drive attachment to transform or slide on segment constraints (e.g. null, joint or rivet nodes) must live in the */obj* context.
-- KineFX joint transforms are not supported.
+Deformed geometry uses the `Shape` suffix to describe the `geometry` entry. This is important when moving data between DCCs, because the geometry name must follow the expected naming convention.
+
+Data such as `geometryAttachments` is represented using the name without the `Shape` suffix. This is also important for interoperability between DCCs.
+
+The `<geo_name>` used in `ADN_IN_<geo_name>` and `ADN_OUT_<geo_name>` should match the equivalent expected shape name in Maya.
+
+## Limitations
+
+- Subnetworks inside the Geometry context are not supported. All Adonis SOP nodes, and any SOP nodes containing geometry required by the Adonis rig, must exist at the same level inside the Geometry context, for example `/obj/geo1`.
+- Nodes used to drive attachment to transform or slide on segment constraints must live in the `/obj` context.
+- Base Matrix reconstruction is not supported in Houdini.
+- Exporting and rebuilding KineFX joint transform hierarchies is not supported by this API.

--- a/docs/houdini/api.md
+++ b/docs/houdini/api.md
@@ -13,7 +13,8 @@ This API enables users to:
 
 - Extract the setup from an existing Adonis rig in Houdini.
 - Rebuild the rig in another Houdini scene.
-- Export rig data in a format that can be imported into other DCCs, for example Maya.
+- Export rig data in a format that can be imported into other DCCs, such as Maya.
+- Build an entire Adonis rig programmatically.
 
 As this API is still under active development, please send feedback and feature requests to **adonis.support@inbibo.co.uk**. The support and development teams will work together to incorporate user feedback and refine the implementation.
 
@@ -155,7 +156,7 @@ Clear a specific rig component from the scene:
 <pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle.clear()
 </code></pre>
 
-In Houdini, clearing a node destroys the corresponding Houdini node. This operation is only expected to work when the network is not cooking.
+In Houdini, clearing a component deletes the corresponding Houdini node. This operation is only expected to work when the network is not cooking.
 
 ## Connections
 
@@ -218,5 +219,3 @@ The `<geo_name>` used in `ADN_IN_<geo_name>` and `ADN_OUT_<geo_name>` should mat
 
 - Subnetworks inside the Geometry context are not supported. All Adonis SOP nodes, and any SOP nodes containing geometry required by the Adonis rig, must exist at the same level inside the Geometry context, for example `/obj/geo1`.
 - Nodes used to drive attachment to transform or slide on segment constraints must live in the `/obj` context.
-- Base Matrix reconstruction is not supported in Houdini.
-- Exporting and rebuilding KineFX joint transform hierarchies is not supported by this API.

--- a/docs/maya/api.md
+++ b/docs/maya/api.md
@@ -1,50 +1,176 @@
-# API
+# Maya Python API
 
-### Experimental Python API
+## Experimental Python API
 
-> [!NOTE]
-> - This API is experimental, and will be subject to changes in following versions of Adonis.
-> - The use of this API in production applications is not supported.
+> [!WARNING]
+> This API is experimental and may change in future versions of Adonis.
+>
+> The use of this API in production applications is not supported.
 
-An experimental Python API has been developed to allow Technical Directors to implement custom Python scripts for exporting and rebuilding Adonis rigs programmatically.
+An experimental Python API is available for Technical Directors who need to implement custom Python scripts for exporting and rebuilding Adonis rigs programmatically.
 
 This API enables users to:
-- Extract the setup from an existing rig in Maya.
+
+- Extract the setup from an existing Adonis rig in Maya.
 - Rebuild the rig in another Maya scene.
-- Export rig data in a format that could be imported into other DCCs (for example Houdini).
+- Export rig data in a format that can be imported into other DCCs, for example Houdini.
 
-As this API is still under active development, please do not hesitate to send an email to **adonis.support@inbibo.co.uk** to provide feedback and/or feature requests. The support and development teams will work together to incorporate user feedback and refine the implementation.
+As this API is still under active development, please send feedback and feature requests to **adonis.support@inbibo.co.uk**. The support and development teams will work together to incorporate user feedback and refine the implementation.
 
-The API can be found in `Adonis/python/adn/api/adnx.py`. 
-The definitions can be imported with `from adn.api.adnx import *`.
+The API can be found in:
 
-Since the method definitions may change before the API becomes production-ready, here are some examples showing how to use the current experimental Python API for Maya. Similar methods can be found directly in the `adnx.py` file.
+`Adonis/python/adn/api/adnx.py`
 
-1. How to create a rig instance with Maya as the host: `rig = AdnRig(AdnHost.kMaya)`.
-2. How to create an Adonis rig component and add it to the rig (e.g. an AdnMuscle inside the rig): `muscle = AdnMuscle(rig)` and `rig.addSolver(muscle)`.
-3. How to gather data from an existing Adonis scene to populate the rig component entry (assuming AdnMuscle1 exists in the Maya scene): `muscle.fromNode("AdnMuscle1")`.
-4. How to get the dictionary containing the extracted data: `data = muscle.getData()`.
-5. How to populate the rig component from a dictionary that contains all required entries: `muscle.fromDict(data)`. The required dictionary formatting can be found in the `__init__` methods of the `AdnMuscleBase` and `AdnMuscle` classes. Modifying dictionary entries allows users to update or rebuild rigs with custom values.
-6. How to update an existing rig component in the scene after modifying its values: `muscle.update()`. This method assumes that the target AdnMuscle already exists in the scene.
-7. How to build rig components in the scene: `muscle.build()` to build the muscle or `rig.build()` to build all the components.
-8. How to define the execution order when extracting data from an existing scene: `rig.buildExecutionOrder()`. With an already configured scene, this deduces the correct reconstruction order required to preserve deformation and node dependency chains.
-9. How to clear a specific rig component from the scene: `muscle.clear()`.
+The definitions can be imported with:
 
-All other methods can be found in the `Adonis/python/adn/api/adnx.py` file.
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">from adn.api.adnx import *
+</code></pre>
 
-The API is the base foundation for the Import/Export tools of Adonis. Below is an example of exported rig data in a .json file:
+The API exposes Adonis rig entities through Python classes and type identifiers. The available classes, supported data entries, and implementation details are defined directly in `adnx.py`.
 
-<figure markdown>
-  ![Maya API Json example](images/maya_api_json_example.png)
-  <figcaption><b>Figure 1</b>: Maya API Json example.</figcaption>
-</figure>
+## Requirements
+
+Before using the Maya Python API, the Maya scene must contain a valid Adonis rig structure.
+
+No context needs to be defined in the current version of the Maya API. The API uses the Maya scene directly when extracting, rebuilding, updating, or clearing Adonis rig components.
+
+The rig data should follow the expected cross-DCC naming conventions when it needs to be transferred between Maya and other DCCs.
+
+Deformed geometry uses the `Shape` suffix to describe the `geometry` entry. This is important when moving data between DCCs, because the geometry name must follow the expected naming convention.
+
+Data such as `geometryAttachments` is represented using the name without the `Shape` suffix. This is also important for interoperability between DCCs.
+
+## Basic Usage Examples
+
+The method definitions may change before the API becomes production-ready. The following examples show how to use the current experimental Python API for Maya.
+
+### Create a Rig Instance
+
+Create a rig instance with Maya as the host:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">rig = AdnRig(AdnHost.kMaya)
+</code></pre>
+
+### Create a Rig Component
+
+Create an Adonis rig component and add it to the rig. For example, to create an **AdnMuscle** component:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle = AdnMuscle(rig)
+rig.addSolver(muscle)
+</code></pre>
+
+Some components are added automatically when they are created with a rig instance, depending on their base class. However, explicitly adding the component to the rig can help make the workflow clearer.
+
+### Extract Data from an Existing Node
+
+Gather data from an existing Adonis node in the Maya scene.
+
+For example, if an **AdnMuscle** node named `AdnMuscle1` exists in the Maya scene:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle.fromNode("AdnMuscle1")
+</code></pre>
+
+### Get Extracted Data
+
+Get the dictionary containing the extracted data:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">data = muscle.getData()
+</code></pre>
+
+The returned dictionary contains the component parameters, maps, connections, node information, and other data required to rebuild or update the component.
+
+### Populate a Component from a Dictionary
+
+Populate a rig component from a dictionary that contains all required entries:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle.fromDict(data)
+</code></pre>
+
+The required dictionary formatting can be found in the `__init__` methods of the corresponding classes, for example `AdnMuscleBase` and `AdnMuscle`.
+
+Modifying dictionary entries allows users to update or rebuild rigs with custom values.
+
+### Update an Existing Component
+
+Update an existing rig component in the scene after modifying its values:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle.update()
+</code></pre>
+
+This method assumes that the target Adonis node already exists in the Maya scene.
+
+### Build Rig Components
+
+Build a single component in the scene:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle.build()
+</code></pre>
+
+Build all components registered in the rig:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">rig.build()
+</code></pre>
+
+### Define the Execution Order
+
+Define the execution order when extracting data from an existing scene:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">rig.buildExecutionOrder()
+</code></pre>
+
+With an already configured scene, this deduces the reconstruction order required to preserve deformation order and node dependency chains.
+
+The execution order is built from:
+
+1. Sensors.
+2. Non-deformable utility nodes.
+3. Deformers and solvers in deformation chain order.
+
+### Clear a Component
+
+Clear a specific rig component from the scene:
+
+<pre><code style="white-space: pre; margin: 20px 0; padding: 10px; box-sizing: border-box;">muscle.clear()
+</code></pre>
+
+In Maya, clearing a component deletes the corresponding Adonis node and the related nodes stored by the component data.
+
+## Connections
+
+The API can extract and rebuild connections between Adonis nodes.
+
+In Maya, connections are represented as direct Maya attribute connections. The API can extract compatible incoming and outgoing connections and serialize them into rig data.
+
+When rebuilding a component, the API attempts to restore the stored connections in the target Maya scene.
 
 > [!NOTE]
-> - Deformed geometry uses the `Shape` suffix to describe the "geometry" entry. This is important when moving data between DCCs, as it must adhere to the naming convention.
-> - Data such as "geometryAttachments" are represented using the name without the `Shape` suffix. This is also important for interoperability between DCCs.
-> - No context needs to be defined in the current version of the Maya API.
-> - Exported connections between Adonis nodes may differ depending on the DCC. This is expected due to differences between DCC applications. However, the rig will be correctly reconstructed when imported into any supported target DCC.
+> Exported connections between Adonis nodes may differ depending on the DCC. This is expected due to differences between DCC applications. However, the rig should be reconstructed correctly when imported into any supported target DCC, as long as the required nodes, geometry, and rig structure are compatible.
 
-### Limitations
+## Exported Rig Data
+
+The API is the foundation for the Import and Export tools in Adonis.
+
+Below is an example of exported rig data in a `.json` file:
+
+<figure markdown>
+  ![Maya API JSON example](images/maya_api_json_example.png)
+  <figcaption><b>Figure 1</b>: Maya API JSON example.</figcaption>
+</figure>
+
+All other methods and data definitions can be found in:
+
+`Adonis/python/adn/api/adnx.py`
+
+## Naming and Interoperability
+
+When transferring data between DCCs, some naming conventions must be respected.
+
+Deformed geometry uses the `Shape` suffix to describe the `geometry` entry. This is important when moving data between DCCs, because the geometry name must follow the expected naming convention.
+
+Data such as `geometryAttachments` is represented using the name without the `Shape` suffix. This is also important for interoperability between DCCs.
+
+If rig data is intended to be rebuilt in Houdini, the geometry names should match the equivalent Houdini deformable region names, such as the names used by `ADN_IN_<geo_name>` and `ADN_OUT_<geo_name>` Null nodes.
+
+## Limitations
 
 - The use of Maya namespaces is not supported by the API.

--- a/docs/maya/api.md
+++ b/docs/maya/api.md
@@ -13,7 +13,8 @@ This API enables users to:
 
 - Extract the setup from an existing Adonis rig in Maya.
 - Rebuild the rig in another Maya scene.
-- Export rig data in a format that can be imported into other DCCs, for example Houdini.
+- Export rig data in a format that can be imported into other DCCs, such as Houdini.
+- Build an entire Adonis rig programmatically.
 
 As this API is still under active development, please send feedback and feature requests to **adonis.support@inbibo.co.uk**. The support and development teams will work together to incorporate user feedback and refine the implementation.
 
@@ -169,7 +170,7 @@ Deformed geometry uses the `Shape` suffix to describe the `geometry` entry. This
 
 Data such as `geometryAttachments` is represented using the name without the `Shape` suffix. This is also important for interoperability between DCCs.
 
-If rig data is intended to be rebuilt in Houdini, the geometry names should match the equivalent Houdini deformable region names, such as the names used by `ADN_IN_<geo_name>` and `ADN_OUT_<geo_name>` Null nodes.
+If rig data is intended to be rebuilt in Houdini, the geometry names should match the equivalent Houdini deformable region names, such as those used in the `ADN_IN_<geo_name>` and `ADN_OUT_<geo_name>` Null nodes.
 
 ## Limitations
 


### PR DESCRIPTION
# Description
This pull request significantly expands and clarifies the documentation for both the Houdini and Maya experimental Python APIs, providing much more detailed guidance, usage examples, requirements, and explanations of limitations and interoperability. The changes make it much easier for technical directors and developers to understand how to use the APIs for exporting, rebuilding, and customizing Adonis rigs programmatically.

The most important changes are:

**Major documentation expansion and restructuring:**
- Both `docs/houdini/api.md` and `docs/maya/api.md` now include comprehensive introductions, explicit requirements, and structured sections for usage, limitations, and interoperability, replacing the previous brief and less organized content. [[1]](diffhunk://#diff-580a7499f35b91353e9e5cb4844c6dc8c6e87e08a6277aae92a3871f3dee9397L1-R222) [[2]](diffhunk://#diff-5456bc64a23647615abc92bb923e469a047de811558ade95d7bd0a054596cf39L1-R174)

**Detailed usage examples and workflows:**
- Added step-by-step code examples for typical API workflows, such as creating rig instances and components, extracting and updating data, building and clearing components, and defining execution order. These examples are now presented in formatted code blocks for clarity. [[1]](diffhunk://#diff-580a7499f35b91353e9e5cb4844c6dc8c6e87e08a6277aae92a3871f3dee9397L1-R222) [[2]](diffhunk://#diff-5456bc64a23647615abc92bb923e469a047de811558ade95d7bd0a054596cf39L1-R174)

**Clarification of DCC-specific requirements and naming conventions:**
- Houdini: Detailed explanation of the required scene structure, use of context, placement of nodes, and geometry separation using Null nodes with naming conventions for cross-DCC compatibility.
- Maya: Explanation of naming conventions for geometry and attachments, and requirements for interoperability with Houdini.

**Expanded documentation on connections and exported data:**
- Both docs now describe how the API handles connections between Adonis nodes, how these are serialized and rebuilt, and what to expect when transferring rigs between DCCs. Example JSON exports and figures are included. [[1]](diffhunk://#diff-580a7499f35b91353e9e5cb4844c6dc8c6e87e08a6277aae92a3871f3dee9397L1-R222) [[2]](diffhunk://#diff-5456bc64a23647615abc92bb923e469a047de811558ade95d7bd0a054596cf39L1-R174)

**Explicit limitations and support notes:**
- Both APIs now clearly list limitations, such as unsupported features (e.g., subnetworks in Houdini, Maya namespaces), and provide warnings about the experimental status and production use. [[1]](diffhunk://#diff-580a7499f35b91353e9e5cb4844c6dc8c6e87e08a6277aae92a3871f3dee9397L1-R222) [[2]](diffhunk://#diff-5456bc64a23647615abc92bb923e469a047de811558ade95d7bd0a054596cf39L1-R174)

# [Preview](https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2F11201fe51575b49647455c6c3e87e623a5f1b3df%2Fdocs%2Fhoudini%2Fapi.md)