### PR TITLE
Update/Fix release date of 2.1.0

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## Version 2.1.0
-2026-06-29
+2026-07-01
 
 ### Core
 - Added support to exclude or include specific target faces in the computation of external constraints in AdnMuscle, AdnRibbonMuscle and AdnSkin solvers.


### PR DESCRIPTION
This pull request updates the release date for version 2.1.0 in the release notes.

- [`docs/release_notes.md`](diffhunk://#diff-3fa44f20fe1c12758e313ededbc4847b3434a9fa307dbcc493bcade14995dd5fL4-R4): Changed the release date for version 2.1.0 from 2026-06-29 to 2026-07-01.