### PR TITLE
Revert to IMPORTANT the temporary NOTES that were not rendering properly

### DIFF
--- a/docs/houdini/scripts/data_extraction.md
+++ b/docs/houdini/scripts/data_extraction.md
@@ -1,6 +1,6 @@
 # Data Extraction
 
-> [!NOTE]
+> [!IMPORTANT]
 > An Adonis ML license is required to use this feature.
 
 In the `adnml.scripts.houdini.data_extraction` module, a Python function is provided to extract data for training AdonisML models from a processed Adonis simulation setup.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ AdonisML can be used to further optimize the efficiency and complexity of an Ado
 - **ML Deformer**: A pose-based neural deformer that provides interactive-speed feedback for high-quality skin deformation.
 - **Smart tissue**: A fast and procedural simulation layer that adds inertial detail such as jiggle, settle, and overshoot, which pose-based ML deformation does not usually capture on its own. This can be further enhanced by the use of a neural network for dynamic material properties prediction.
 
-> [!NOTE]
+> [!IMPORTANT]
 > ML Deformer and Smart Tissue can be used within an Adonis FX license, however data extraction and training of Adonis ML models are allowed for Adonis ML license. See more info in [this section](licensing#adonis-bundles).
 
 The ML Deformer allows animators to work interactively with a high-quality representation of the character deformation. Because pose-based ML deformers are trained from pose data, their output is based on the current pose and does not directly represent motion, velocity, or dynamic history.

--- a/docs/maya/scripts/data_extraction.md
+++ b/docs/maya/scripts/data_extraction.md
@@ -1,6 +1,6 @@
 # Data Extraction
 
-> [!NOTE]
+> [!IMPORTANT]
 > An Adonis ML license is required to use this feature.
 
 In the `adnml.scripts.maya.data_extraction` module, a Python function is provided to extract data for training AdonisML models from a processed Adonis simulation setup.


### PR DESCRIPTION
## Description

This pull request updates the documentation to clarify licensing requirements for data extraction and training features. The most important changes are:

**Documentation improvements:**

* Changed callout from `[!NOTE]` to `[!IMPORTANT]` in `docs/houdini/scripts/data_extraction.md`, `docs/maya/scripts/data_extraction.md`, and `docs/index.md` to better highlight that an Adonis ML license is required for data extraction and training features. [[1]](diffhunk://#diff-8de19138a5acacecb368bc1faafa93c6f17cfbd5a301b901132829b145c39ebbL3-R3) [[2]](diffhunk://#diff-c0c6914f7380a7ced0dc89182cc8da8a5eca33564a29f6ee408c0245123056e5L3-R3) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L31-R31)

## Test

- index: https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2F44276c4450cc518440ffc8f485bda39c403bfb1a%2Fdocs%2Findex.md
- maya scripts data extraction: https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2F44276c4450cc518440ffc8f485bda39c403bfb1a%2Fdocs%2Fmaya%2Fscripts%2Fdata_extraction.md
- houdini scripts data extraction: https://inbibo.co.uk/docs/preview?sheet_url=https%3A%2F%2Fgithub.com%2FInbibo%2Fadonisfx_docs%2Fblob%2F44276c4450cc518440ffc8f485bda39c403bfb1a%2Fdocs%2Fhoudini%2Fscripts%2Fdata_extraction.md